### PR TITLE
Setup tweaks for clean installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 AiiDA Siesta plugins and workflows
 ==================================
 
-This repository contains the files that implement the AiiDA Siesta
-plugins and a set of related AiiDA workflows.
+A plugin with `Siesta DFT code <https://departments.icmab.es/leem/siesta/>`_
+interface to the `AiiDA system <http://www.aiida.net/>`_.
 
 Documentation can be found in:
 
@@ -14,30 +14,27 @@ Installation and usage guidelines
 Installation
 ~~~~~~~~~~~~
 
-The distribution package of the plugin is available on PyPI.
-To install it directly from the index run:
+``aiida-siesta`` is compatible with latest release of AiiDA.
+
+To install it directly from PyPI run:
 
 ::
 
-       pip install --process-dependency-links aiida-siesta
+       pip install aiida-siesta
 
-However, at this development stage ``aiida\_siesta`` uses a custom version of ``aiida\_core``, to work around a few issues relevant to the Siesta plugin. Thus, using package from PyPI is not recommended at the moment, since the installation relies on deprecated ``--process-dependency-links`` flag.
 
-For a more suitable development setup (including custom ``aiida\_core`` installation) see the section below.
+Development guide
+~~~~~~~~~~~~~~~~~
+
+For development and testing purposes, create and activate python ``virtualenv`` environment instance, then follow the steps below:
 
 
 Local environment setup
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Use your own installation of the database, and your own computers and
-codes.
-
-Assuming that you are
-at the top-level of the Siesta AiiDA plugin hierarchy, do:
-
 ::
 
-       git clone https://github.com/vdikan/aiida_core
+       git clone https://github.com/aiidateam/aiida_core
        cd aiida_core
        git checkout develop
 

--- a/README.rst
+++ b/README.rst
@@ -65,12 +65,11 @@ Development tests
 ^^^^^^^^^^^^^^^^^
 
 It is possible now to run development tests located in
-``aiida_siesta/tests/`` via *pytest*. The approach was originally
-implemented by **Dominik Gresch** in his
-`aiida\_pytest <https://github.com/greschd/aiida_pytest>`__ module.
+``aiida_siesta/tests/`` via *pytest*.
+The approach we use for unit- and integrity testing is implemented
+by **Dominik Gresch** in his `aiida\_pytest <https://github.com/greschd/aiida_pytest>`__ module.
 
-In order to run tests, after you install core and plugin as described
-above, run:
+In order to run tests, after you install core and plugin as described above, run:
 
 ::
 

--- a/aiida_siesta/commands/psfdata.py
+++ b/aiida_siesta/commands/psfdata.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+"""
+Verdi command definition for PSF pseudopotentials data.
+`verdi data psf`
+"""
+import sys
+
+from aiida.backends.utils import is_dbenv_loaded, load_dbenv
+from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
+from aiida.cmdline.commands.data import Importable
+
+
+class _Psf(VerdiCommandWithSubcommands, Importable):
+    """
+    Setup and manage psf to be used
+
+    This command allows to list and configure psf pseudos.
+    """
+
+    def __init__(self):
+        """
+        A dictionary with valid commands and functions to be called.
+        """
+        if not is_dbenv_loaded():
+            load_dbenv()
+        # from aiida.orm.data.upf import UpfData
+        from aiida_siesta.data.psf import PsfData
+
+        self.dataclass = PsfData
+        self.valid_subcommands = {
+            'uploadfamily': (self.uploadfamily, self.complete_auto),
+            'listfamilies': (self.listfamilies, self.complete_none),
+            'import': (self.importfile, self.complete_none),
+            'exportfamily': (self.exportfamily, self.complete_auto)
+        }
+
+    def uploadfamily(self, *args):
+        """
+        Upload a new pseudopotential family.
+
+        Returns the numbers of files found and the number of nodes uploaded.
+
+        Call without parameters to get some help.
+        """
+        import os.path
+
+        if not len(args) == 3 and not len(args) == 4:
+            print >> sys.stderr, (
+                "After 'psf uploadfamily' there should be three "
+                "arguments:")
+            print >> sys.stderr, ("folder, group_name, group_description "
+                                  "[OPTIONAL: --stop-if-existing]\n")
+            sys.exit(1)
+
+        folder = os.path.abspath(args[0])
+        group_name = args[1]
+        group_description = args[2]
+        stop_if_existing = False
+
+        if len(args) == 4:
+            if args[3] == "--stop-if-existing":
+                stop_if_existing = True
+            else:
+                print >> sys.stderr, 'Unknown directive: ' + args[3]
+                sys.exit(1)
+
+        if (not os.path.isdir(folder)):
+            print >> sys.stderr, 'Cannot find directory: ' + folder
+            sys.exit(1)
+
+        # import aiida.orm.data.upf as upf
+        import aiida_siesta.data.psf as psf
+
+        files_found, files_uploaded = psf.upload_psf_family(
+            folder, group_name, group_description, stop_if_existing)
+
+        print "PSF files found: {}. New files uploaded: {}".format(
+            files_found, files_uploaded)
+
+    def listfamilies(self, *args):
+        """
+        Print on screen the list of psf families installed
+        """
+        # note that the following command requires that the psfdata has a
+        # key called element. As such, it is not well separated.
+        import argparse
+
+        parser = argparse.ArgumentParser(
+            prog=self.get_full_command_name(),
+            description='List AiiDA psf families.')
+        parser.add_argument(
+            '-e',
+            '--element',
+            nargs='+',
+            type=str,
+            default=None,
+            help="Filter the families only to those containing "
+            "a pseudo for each of the specified elements")
+        parser.add_argument(
+            '-d',
+            '--with-description',
+            dest='with_description',
+            action='store_true',
+            help="Show also the description for the PSF family")
+        parser.set_defaults(with_description=False)
+
+        args = list(args)
+        parsed_args = parser.parse_args(args)
+
+        from aiida.orm import DataFactory
+        # from aiida.orm.data.upf import UPFGROUP_TYPE
+        from aiida_siesta.data.psf import PSFGROUP_TYPE
+
+        PsfData = DataFactory('siesta.psf')
+        from aiida.orm.querybuilder import QueryBuilder
+        from aiida.orm.group import Group
+        qb = QueryBuilder()
+        qb.append(PsfData, tag='psfdata')
+        if parsed_args.element is not None:
+            qb.add_filter(PsfData,
+                          {'attributes.element': {
+                              'in': parsed_args.element
+                          }})
+        qb.append(
+            Group,
+            group_of='psfdata',
+            tag='group',
+            project=["name", "description"],
+            filters={"type": {
+                '==': PSFGROUP_TYPE
+            }})
+
+        qb.distinct()
+        if qb.count() > 0:
+            for res in qb.dict():
+                group_name = res.get("group").get("name")
+                group_desc = res.get("group").get("description")
+                qb = QueryBuilder()
+                qb.append(
+                    Group,
+                    tag='thisgroup',
+                    filters={"name": {
+                        'like': group_name
+                    }})
+                qb.append(PsfData, project=["id"], member_of='thisgroup')
+
+                if parsed_args.with_description:
+                    description_string = ": {}".format(group_desc)
+                else:
+                    description_string = ""
+
+                print "* {} [{} pseudos]{}".format(group_name,
+                                                   qb.count(),
+                                                   description_string)
+
+        else:
+            print "No valid PSF pseudopotential family found."
+
+    def exportfamily(self, *args):
+        """
+        Export a pseudopotential family into a folder.
+        Call without parameters to get some help.
+        """
+        import os
+        from aiida.common.exceptions import NotExistent
+        from aiida.orm import DataFactory
+
+        if not len(args) == 2:
+            print >> sys.stderr, ("After 'psf export' there should be two "
+                                  "arguments:")
+            print >> sys.stderr, ("folder, psf_family_name\n")
+            sys.exit(1)
+
+        folder = os.path.abspath(args[0])
+        group_name = args[1]
+
+        PsfData = DataFactory('siesta.psf')
+        try:
+            group = PsfData.get_psf_group(group_name)
+        except NotExistent:
+            print >> sys.stderr, ("psf family {} not found".format(group_name))
+
+        for u in group.nodes:
+            dest_path = os.path.join(folder, u.filename)
+            if not os.path.isfile(dest_path):
+                with open(dest_path, 'w') as dest:
+                    with u._get_folder_pathsubfolder.open(
+                            u.filename) as source:
+                        dest.write(source.read())
+            else:
+                print >> sys.stdout, ("File {} is already present in the "
+                                      "destination folder".format(u.filename))
+
+    def _import_psf(self, filename, **kwargs):
+        """
+        Importer from PSF.
+        """
+        try:
+            node, _ = self.dataclass.get_or_create(filename)
+            print node
+        except ValueError as e:
+            print e

--- a/aiida_siesta/data/psf.py
+++ b/aiida_siesta/data/psf.py
@@ -2,9 +2,9 @@
 """
 This module manages the PSF pseudopotentials in the local repository.
 """
-from aiida.orm.data.singlefile import SinglefileData
+
 from aiida.common.utils import classproperty
-import re
+from aiida.orm.data.singlefile import SinglefileData
 
 __copyright__ = u"Copyright (c), 2015, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE (Theory and Simulation of Materials (THEOS) and National Centre for Computational Design and Discovery of Novel Materials (NCCR MARVEL)), Switzerland and ROBERT BOSCH LLC, USA. All rights reserved."
 __license__ = "MIT license, see LICENSE.txt file"
@@ -12,6 +12,7 @@ __version__ = "0.9.0"
 __contributors__ = "Victor M. Garcia-Suarez, Andrea Cepellotti"
 
 PSFGROUP_TYPE = 'data.psf.family'
+
 
 def get_pseudos_from_structure(structure, family_name):
     """
@@ -42,14 +43,15 @@ def get_pseudos_from_structure(structure, family_name):
         try:
             pseudo_list[kind.name] = family_pseudos[symbol]
         except KeyError:
-            raise NotExistent("No PSF for element {} found in family {}".format(
-                symbol, family_name))
+            raise NotExistent("No PSF for element {} found in family {}".
+                              format(symbol, family_name))
 
     return pseudo_list
 
 
-
-def upload_psf_family(folder, group_name, group_description,
+def upload_psf_family(folder,
+                      group_name,
+                      group_description,
                       stop_if_existing=True):
     """
     Upload a set of PSF files in a given group.
@@ -76,10 +78,11 @@ def upload_psf_family(folder, group_name, group_description,
 
     # only files, and only those ending with .psf or .PSF;
     # go to the real file if it is a symlink
-    files = [os.path.realpath(os.path.join(folder,i))
-             for i in os.listdir(folder) if
-             os.path.isfile(os.path.join(folder,i)) and
-             i.lower().endswith('.psf')]
+    files = [
+        os.path.realpath(os.path.join(folder, i)) for i in os.listdir(folder)
+        if os.path.isfile(os.path.join(folder, i)) and
+        i.lower().endswith('.psf')
+    ]
 
     nfiles = len(files)
 
@@ -87,15 +90,17 @@ def upload_psf_family(folder, group_name, group_description,
         group = Group.get(name=group_name, type_string=PSFGROUP_TYPE)
         group_created = False
     except NotExistent:
-        group = Group(name=group_name, type_string=PSFGROUP_TYPE,
-                        user=get_automatic_user())
+        group = Group(
+            name=group_name,
+            type_string=PSFGROUP_TYPE,
+            user=get_automatic_user())
         group_created = True
 
     if group.user != get_automatic_user():
         raise UniquenessError("There is already a PsfFamily group with name {}"
                               ", but it belongs to user {}, therefore you "
-                              "cannot modify it".format(group_name,
-                                                        group.user.email))
+                              "cannot modify it".format(
+                                  group_name, group.user.email))
 
     # Always update description, even if the group already existed
     group.description = group_description
@@ -107,33 +112,29 @@ def upload_psf_family(folder, group_name, group_description,
     for f in files:
         md5sum = aiida.common.utils.md5_file(f)
         qb = QueryBuilder()
-        qb.append(PsfData, filters={'attributes.md5':{'==':md5sum}})
+        qb.append(PsfData, filters={'attributes.md5': {'==': md5sum}})
         existing_psf = qb.first()
 
         #existing_psf = PsfData.query(dbattributes__key="md5",
-         #                            dbattributes__tval = md5sum)
-
-
+        #                            dbattributes__tval = md5sum)
 
         if existing_psf is None:
             # return the psfdata instances, not stored
-            pseudo, created = PsfData.get_or_create(f, use_first = True,
-                                                    store_psf = False)
+            pseudo, created = PsfData.get_or_create(
+                f, use_first=True, store_psf=False)
             # to check whether only one psf per element exists
             # NOTE: actually, created has the meaning of "to_be_created"
-            pseudo_and_created.append((pseudo,created))
+            pseudo_and_created.append((pseudo, created))
         else:
             if stop_if_existing:
-                raise ValueError(
-                        "A PSF with identical MD5 to "
-                        " {} cannot be added with stop_if_existing"
-                        "".format(f)
-                    )
+                raise ValueError("A PSF with identical MD5 to "
+                                 " {} cannot be added with stop_if_existing"
+                                 "".format(f))
             existing_psf = existing_psf[0]
             pseudo_and_created.append((existing_psf, False))
 
     # check whether pseudo are unique per element
-    elements = [(i[0].element, i[0].md5sum) for i in pseudo_and_created ]
+    elements = [(i[0].element, i[0].md5sum) for i in pseudo_and_created]
     # If group already exists, check also that I am not inserting more than
     # once the same element
     if not group_created:
@@ -143,31 +144,31 @@ def upload_psf_family(folder, group_name, group_description,
                 continue
             elements.append((aiida_n.element, aiida_n.md5sum))
 
-    elements = set(elements) # Discard elements with the same MD5, that would
-                             # not be stored twice
+    elements = set(elements)  # Discard elements with the same MD5, that would
+    # not be stored twice
     elements_names = [e[0] for e in elements]
 
-    if not len(elements_names) == len(set(elements_names) ):
-        duplicates = set([x for x in elements_names
-                          if elements_names.count(x) > 1])
+    if not len(elements_names) == len(set(elements_names)):
+        duplicates = set(
+            [x for x in elements_names if elements_names.count(x) > 1])
         duplicates_string = ", ".join(i for i in duplicates)
         raise UniquenessError("More than one PSF found for the elements: " +
-                              duplicates_string+".")
+                              duplicates_string + ".")
 
     # At this point, save the group, if still unstored
     if group_created:
         group.store()
 
     # save the psf in the database, and add them to group
-    for pseudo,created in pseudo_and_created:
+    for pseudo, created in pseudo_and_created:
         if created:
             pseudo.store()
 
             aiidalogger.debug("New node {} created for file {}".format(
-               pseudo.uuid, pseudo.filename))
+                pseudo.uuid, pseudo.filename))
         else:
             aiidalogger.debug("Reusing node {} for file {}".format(
-               pseudo.uuid, pseudo.filename))
+                pseudo.uuid, pseudo.filename))
 
     # Add elements to the group all togetehr
     group.add_nodes(pseudo for pseudo, created in pseudo_and_created)
@@ -177,7 +178,7 @@ def upload_psf_family(folder, group_name, group_description,
     return nfiles, nuploaded
 
 
-def parse_psf(fname, check_filename = True):
+def parse_psf(fname, check_filename=True):
     """
     Try to get relevant information from the PSF. For the moment, only the
     element name.
@@ -187,7 +188,6 @@ def parse_psf(fname, check_filename = True):
     import os
 
     from aiida.common.exceptions import ParsingError
-    from aiida.common import aiidalogger
     # TODO: move these data in a 'chemistry' module
     from aiida.orm.data.structure import _valid_symbols
 
@@ -202,16 +202,15 @@ def parse_psf(fname, check_filename = True):
 
         # Only first letter capitalized!
         if element is None:
-            raise ParsingError("Unable to find the element of PSF {}".format(
-                    fname))
+            raise ParsingError(
+                "Unable to find the element of PSF {}".format(fname))
         element = element.capitalize()
         if element not in _valid_symbols:
-            raise ParsingError("Unknown element symbol {} for file {}".format(
-                element, fname))
+            raise ParsingError(
+                "Unknown element symbol {} for file {}".format(element, fname))
 
         if check_filename:
-            if not os.path.basename(fname).lower().startswith(
-                  element.lower()):
+            if not os.path.basename(fname).lower().startswith(element.lower()):
                 raise ParsingError("Filename {0} was recognized for element "
                                    "{1}, but the filename does not start "
                                    "with {1}".format(fname, element))
@@ -221,16 +220,13 @@ def parse_psf(fname, check_filename = True):
     return parsed_data
 
 
-
-
-
 class PsfData(SinglefileData):
     """
     Function not yet documented.
     """
 
     @classmethod
-    def get_or_create(cls,filename,use_first = False,store_psf=True):
+    def get_or_create(cls, filename, use_first=False, store_psf=True):
         """
         Pass the same parameter of the init; if a file with the same md5
         is found, that PsfData is returned.
@@ -247,7 +243,6 @@ class PsfData(SinglefileData):
         """
         import aiida.common.utils
         import os
-        from aiida.common.exceptions import ParsingError
 
         if not os.path.abspath(filename):
             raise ValueError("filename must be an absolute path")
@@ -266,10 +261,11 @@ class PsfData(SinglefileData):
                 if use_first:
                     return (pseudos[0], False)
                 else:
-                    raise ValueError("More than one copy of a pseudopotential "
+                    raise ValueError(
+                        "More than one copy of a pseudopotential "
                         "with the same MD5 has been found in the "
                         "DB. pks={}".format(
-                          ",".join([str(i.pk) for i in pseudos])))
+                            ",".join([str(i.pk) for i in pseudos])))
             else:
                 return (pseudos[0], False)
 
@@ -303,7 +299,6 @@ class PsfData(SinglefileData):
 
         return super(PsfData, self).store(*args, **kwargs)
 
-
     @classmethod
     def from_md5(cls, md5):
         """
@@ -331,7 +326,7 @@ class PsfData(SinglefileData):
             raise ParsingError("No 'element' parsed in the PSF file {};"
                                " unable to store".format(self.filename))
 
-        super(PsfData,self).set_file(filename)
+        super(PsfData, self).set_file(filename)
 
         self._set_attr('element', str(element))
         self._set_attr('md5', md5sum)
@@ -342,8 +337,11 @@ class PsfData(SinglefileData):
         """
         from aiida.orm import Group
 
-        return [_.name for _ in Group.query(nodes=self,
-                                            type_string=self.psffamily_type_string)]
+        return [
+            _.name
+            for _ in Group.query(
+                nodes=self, type_string=self.psffamily_type_string)
+        ]
 
     @property
     def element(self):
@@ -357,7 +355,7 @@ class PsfData(SinglefileData):
         from aiida.common.exceptions import ValidationError, ParsingError
         import aiida.common.utils
 
-        super(PsfData,self)._validate()
+        super(PsfData, self)._validate()
 
         psf_abspath = self.get_file_abs_path()
         if not psf_abspath:
@@ -389,26 +387,24 @@ class PsfData(SinglefileData):
         if attr_element != element:
             raise ValidationError("Attribute 'element' says '{}' but '{}' was "
                                   "parsed instead.".format(
-                    attr_element, element))
+                                      attr_element, element))
 
         if attr_md5 != md5:
             raise ValidationError("Attribute 'md5' says '{}' but '{}' was "
-                                  "parsed instead.".format(
-                    attr_md5, md5))
-
+                                  "parsed instead.".format(attr_md5, md5))
 
     @classmethod
-    def get_psf_group(cls,group_name):
+    def get_psf_group(cls, group_name):
         """
         Return the PsfFamily group with the given name.
         """
         from aiida.orm import Group
 
-        return Group.get(name=group_name, type_string=cls.psffamily_type_string)
-
+        return Group.get(
+            name=group_name, type_string=cls.psffamily_type_string)
 
     @classmethod
-    def get_psf_groups(cls,filter_elements=None, user=None):
+    def get_psf_groups(cls, filter_elements=None, user=None):
         """
         Return all names of groups of type PsfFamily, possibly with some filters.
 
@@ -434,7 +430,8 @@ class PsfData(SinglefileData):
             actual_filter_elements = {_.capitalize() for _ in filter_elements}
 
             group_query_params['node_attributes'] = {
-                'element': actual_filter_elements}
+                'element': actual_filter_elements
+            }
 
         all_psf_groups = Group.query(**group_query_params)
 

--- a/aiida_siesta/tests/config.yml
+++ b/aiida_siesta/tests/config.yml
@@ -1,19 +1,21 @@
 computers:
-  - name: localhost
+  localhost:
     hostname: localhost
     description: localhost
     transport: local
     scheduler: direct
     work_directory: /tmp/test_aiida_pytest_run
+    queue_name: test_queue_name
 
 codes:
-  - label: tsiesta
+  tsiesta:
     description: test siesta code object
     default_plugin: siesta.siesta
     remote_computer: localhost
     remote_abspath: /usr/bin/siesta
 
-psf_families:
-  - folder: ./pseudos
-    group_name: test_psf_family
+pseudo_families:
+  test_psf_family:
+    command_name: aiida.cmdline.commands.data._Psf
+    folder: ./pseudos
     group_description: test psf pseudopotentials family

--- a/aiida_siesta/tests/config.yml
+++ b/aiida_siesta/tests/config.yml
@@ -16,6 +16,6 @@ codes:
 
 pseudo_families:
   test_psf_family:
-    command_name: aiida.cmdline.commands.data._Psf
+    command_name: aiida_siesta.commands.psfdata._Psf
     folder: ./pseudos
     group_description: test psf pseudopotentials family

--- a/aiida_siesta/tests/test_cmdline.py
+++ b/aiida_siesta/tests/test_cmdline.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from plum.util import load_class
+
+
+def test_psf_command():
+    pseudo_cmd = load_class('aiida_siesta.commands.psfdata._Psf')
+
+    assert 'uploadfamily' in dir(pseudo_cmd)
+    assert 'listfamilies' in dir(pseudo_cmd)
+    assert '_import_psf' in dir(pseudo_cmd)
+    assert 'exportfamily' in dir(pseudo_cmd)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-#[bdist_wheel]
-#universal = 1
-
 [metadata]
 description-file = README.rst

--- a/setup.json
+++ b/setup.json
@@ -30,6 +30,9 @@
         ],
         "aiida.data": [
             "siesta.psf = aiida_siesta.data.psf:PsfData"
+        ],
+        "aiida.cmdline.data": [
+            "psf = aiida_siesta.commands.psfdata:_Psf"
         ]
     }
 }

--- a/setup.json
+++ b/setup.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.7.0",
+    "version": "0.9.7.1",
     "name": "aiida_siesta",
     "url": "https://github.com/albgar/aiida_siesta_plugin",
     "download_url": "https://github.com/vdikan/aiida_siesta_plugin/archive/0.9.7.tar.gz",

--- a/setup.json
+++ b/setup.json
@@ -14,7 +14,8 @@
         "Development Status :: 3 - Alpha"
     ],
     "install_requires": [
-        "aiida_core[docs,atomic_tools]==0.9.0"
+        "aiida_core[docs,atomic_tools]==0.9.0",
+        "reentry>=1.0.2"
     ],
     "dependency_links": [
         "git+https://github.com/vdikan/aiida_core.git@develop#egg=aiida_core"

--- a/setup.json
+++ b/setup.json
@@ -14,11 +14,8 @@
         "Development Status :: 3 - Alpha"
     ],
     "install_requires": [
-        "aiida_core[docs,atomic_tools]==0.9.0",
+        "aiida_core[docs,atomic_tools]==0.9.1",
         "reentry>=1.0.2"
-    ],
-    "dependency_links": [
-        "git+https://github.com/vdikan/aiida_core.git@develop#egg=aiida_core"
     ],
     "entry_points": {
         "aiida.calculations": [

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ if __name__ == '__main__':
         include_package_data=True,
         packages=find_packages(),
         long_description=read('README.rst'),
+        reentry_register=True,
         **kwargs)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/vdikan/aiida_pytest.git@siesta#egg=aiida_pytest
+git+https://github.com/greschd/aiida_pytest.git@master#egg=aiida_pytest
 git+https://github.com/greschd/pgtest.git@master#egg=pgtest


### PR DESCRIPTION
Changes in this request clear issues that made us using our own branches of `aiida_core` and `aiida_pytest`.
Thus the plugin can be installed now by simply `pip install aiida-siesta` in a fresh virtualenv.
