### PR TITLE
Resolved inconsistency between spec.inp and fixed filepath

### DIFF
--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -28,17 +28,17 @@ class SiestaCalculation(CalcJob):
     """
     Siesta calculator class for AiiDA.
     """
-    _siesta_plugin_version = 'aiida-1.0.0b--plugin-1.0-migration'
+    _siesta_plugin_version = '1.0.0'
 
     ###########################################################
     ## Important distinction between input.spec of the class ##
-    ## (can be modified) and pure parameters                 ##
+    ## (can be modified) and pure parameters, stored as      ##
+    ## class variables only                                  ##
     ###########################################################
 
-    # Parameters
-    # Keywords that cannot be set
-    # We need to canonicalize this!
-
+    # Parameters stored as class variables
+    # 1) Keywords that cannot be set (need to canonoze this?)
+    # 2) Filepaths of certain outputs
     _aiida_blocked_keywords = ['system-name', 'system-label']
     _aiida_blocked_keywords.append('number-of-species')
     _aiida_blocked_keywords.append('number-of-atoms')
@@ -53,19 +53,19 @@ class SiestaCalculation(CalcJob):
     _PSEUDO_SUBFOLDER = './'
     _OUTPUT_SUBFOLDER = './'
     _PREFIX = 'aiida'
-
-    # Default of the input.spec, it's just default, but user
-    # could change the name
-    _DEFAULT_INPUT_FILE = 'aiida.fdf'
-    _DEFAULT_OUTPUT_FILE = 'aiida.out'
     _DEFAULT_XML_FILE = 'aiida.xml'
     _DEFAULT_JSON_FILE = 'time.json'
     _DEFAULT_MESSAGES_FILE = 'MESSAGES'
     _DEFAULT_BANDS_FILE = 'aiida.bands'
 
+
+    # Default of the input.spec, it's just default, but user
+    # could change the name
+    _DEFAULT_INPUT_FILE = 'aiida.fdf'
+    _DEFAULT_OUTPUT_FILE = 'aiida.out'
+
     # in restarts, it will copy from the parent the following
     # (fow now, just the density matrix file)
-    # _restart_copy_from = os.path.join(self._OUTPUT_SUBFOLDER, '*.DM')
     _restart_copy_from = os.path.join(_OUTPUT_SUBFOLDER, '*.DM')
 
     # in restarts, it will copy the previous folder in the following one
@@ -75,6 +75,7 @@ class SiestaCalculation(CalcJob):
     def define(cls, spec):
         super(SiestaCalculation, cls).define(spec)
 
+        # Input nodes
         spec.input('code', valid_type=orm.Code, help='Input code')
         spec.input('structure',
                    valid_type=orm.StructureData,
@@ -108,30 +109,21 @@ class SiestaCalculation(CalcJob):
                   help='Input pseudo potentials',
                   dynamic=True)
 
-        # These are optional, since a default is specified
-        # But they should not be set by the user...
+        # Metadada.options host the inputs that are not stored
+        # as a separate node, but attached to `CalcJobNode`
+        # as attributes. They are optional, since a default is 
+        # specified, but they might be changed by the user.
         spec.input('metadata.options.input_filename',
                    valid_type=six.string_types,
                    default=cls._DEFAULT_INPUT_FILE)
         spec.input('metadata.options.output_filename',
                    valid_type=six.string_types,
                    default=cls._DEFAULT_OUTPUT_FILE)
-        spec.input('metadata.options.xml_file',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_XML_FILE)
-        spec.input('metadata.options.bands_file',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_BANDS_FILE)
-        spec.input('metadata.options.messages_file',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_MESSAGES_FILE)
-        spec.input('metadata.options.json_file',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_JSON_FILE)
         spec.input('metadata.options.parser_name',
                    valid_type=six.string_types,
                    default='siesta.parser')
-#----------------------------------------------------
+
+        # Output nodes
         spec.output('output_parameters',
                     valid_type=Dict,
                     required=True,
@@ -145,8 +137,9 @@ class SiestaCalculation(CalcJob):
                     valid_type=BandsData,
                     required=False,
                     help='Optional band structure')
-        #I don't know why the bands parameters are parsed as BandsData already contains the kpoints (Emanuele)
-        #AG: Agreed, this will go soon.
+        # I don't know why the bands parameters are parsed as BandsData already 
+        # contains the kpoints (Emanuele)
+        # AG: Agreed, this will go soon.
         spec.output('bands_parameters',
                     valid_type=Dict,
                     required=False,
@@ -156,15 +149,19 @@ class SiestaCalculation(CalcJob):
                     required=False,
                     help='Optional forces and stress')
 
-        spec.default_output_node = 'output_parameters'  #should be existing output node and a Dict
+        # Option that allows acces through node.res
+        # should be existing output node and a Dict
+        spec.default_output_node = 'output_parameters'
 
+        # Error handeling
         spec.exit_code(
             100,
             'ERROR_NO_RETRIEVED_FOLDER',
             message='The retrieved folder data node could not be accessed.')
-        spec.exit_code(120,
-                       'SCF_NOT_CONV',
-                       message='Calculation did not reach scf convergence!')
+        spec.exit_code(
+            120,
+            'SCF_NOT_CONV',
+            message='Calculation did not reach scf convergence!')
         spec.exit_code(
             130,
             'GEOM_NOT_CONV',
@@ -181,12 +178,12 @@ class SiestaCalculation(CalcJob):
         :return: `aiida.common.datastructures.CalcInfo` instance
         """
 
-        ########################################
-        # BEGINNING OF INITIAL INPUT CHECK     #
-        # All input ports that are defined via #
-        # spec.input are required by default,  #
-        # no need to check them                #
-        ########################################
+        #####################################################
+        # BEGINNING OF INITIAL INPUT CHECK                  #
+        # All input ports that are defined via spec.input   #
+        # are checked by default, only need to asses their  #
+        # presence in case they are optional                #
+        #####################################################
 
         code = self.inputs.code
         structure = self.inputs.structure
@@ -246,7 +243,6 @@ class SiestaCalculation(CalcJob):
 
         # Look for blocked keywords and
         # add the proper values to the dictionary
-
         for blocked_key in self._aiida_blocked_keywords:
             canonical_blocked = FDFDict.translate_key(blocked_key)
             for key in input_params:
@@ -260,18 +256,14 @@ class SiestaCalculation(CalcJob):
         input_params.update({'system-label': self._PREFIX})
         input_params.update({'use-tree-timer': 'T'})
         input_params.update({'xml-write': 'T'})
-
         input_params.update({'number-of-species': len(structure.kinds)})
         input_params.update({'number-of-atoms': len(structure.sites)})
 
-        #
         # Regarding the lattice-constant parameter:
         # -- The variable "alat" is not typically kept anywhere, and
         # has already been used to define the vectors.
         # We need to specify that the units of these vectors are Ang...
-
         input_params.update({'lattice-constant': '1.0 Ang'})
-
         # Note that this  will break havoc with the band-k-points "pi/a"
         # option. The use of this option should be banned.
 
@@ -488,21 +480,19 @@ class SiestaCalculation(CalcJob):
             infile.write("max.walltime {}".format(
                 metadataoption.max_wallclock_seconds))
 
+        # ====================== Code and Calc info ========================
+        # Code information object and Calc information object are now
+        # only used to set up the CMDLINE (the bash line that launches siesta)
+        # and to set up the list of files to retrieve.
+
         cmdline_params = settings_dict.pop('CMDLINE', [])
-        #
-        # Code information object
-        #
+        
         codeinfo = CodeInfo()
         codeinfo.cmdline_params = list(cmdline_params)
         codeinfo.stdin_name = metadataoption.input_filename
         codeinfo.stdout_name = metadataoption.output_filename
-        codeinfo.xml_name = metadataoption.xml_file
-        codeinfo.json_name = metadataoption.json_file
-        codeinfo.messages_name = metadataoption.messages_file
         codeinfo.code_uuid = code.uuid
-        #
-        # Calc information object
-        #
+        
         calcinfo = CalcInfo()
         calcinfo.uuid = str(self.uuid)
         if cmdline_params:
@@ -511,26 +501,17 @@ class SiestaCalculation(CalcJob):
         calcinfo.remote_copy_list = remote_copy_list
         calcinfo.stdin_name = metadataoption.input_filename
         calcinfo.stdout_name = metadataoption.output_filename
-        calcinfo.xml_name = metadataoption.xml_file
-        calcinfo.json_name = metadataoption.json_file
-        calcinfo.messages_name = metadataoption.messages_file
         calcinfo.codes_info = [codeinfo]
-        #
-
         # Retrieve by default: the output file, the xml file, the
         # messages file, and the json timing file.
-        # If flagbands=True we also add the bands file to the retrieve list!
-        # This is extremely important because the parser parses the bands
-        # only if aiida.bands is in the retrieve list!!
-
+        # If bandskpoints, also the bands file is added to the retrieve list.
         calcinfo.retrieve_list = []
         calcinfo.retrieve_list.append(metadataoption.output_filename)
-        calcinfo.retrieve_list.append(metadataoption.xml_file)
-        calcinfo.retrieve_list.append(metadataoption.json_file)
-        calcinfo.retrieve_list.append(metadataoption.messages_file)
+        calcinfo.retrieve_list.append(self._DEFAULT_XML_FILE) 
+        calcinfo.retrieve_list.append(self._DEFAULT_JSON_FILE) 
+        calcinfo.retrieve_list.append(self._DEFAULT_MESSAGES_FILE) 
         if bandskpoints is not None:
-            calcinfo.retrieve_list.append(metadataoption.bands_file)
-
+            calcinfo.retrieve_list.append(self._DEFAULT_BANDS_FILE) 
         # Any other files specified in the settings dictionary
         settings_retrieve_list = settings_dict.pop('ADDITIONAL_RETRIEVE_LIST',
                                                    [])

--- a/aiida_siesta/calculations/tkdict.py
+++ b/aiida_siesta/calculations/tkdict.py
@@ -12,7 +12,14 @@
 
 """
 from __future__ import absolute_import
-from collections import MutableMapping
+#MutableMapping and other "abstract base classes" are in collections.abc from
+#python 3.3. "from collections import MutableMapping" is not supported
+#anymore in python 3.8, however it is the only option in python 2.7
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
 import six
 
 

--- a/aiida_siesta/examples/plugins/siesta/example_cif_bands.py
+++ b/aiida_siesta/examples/plugins/siesta/example_cif_bands.py
@@ -49,7 +49,7 @@ except IndexError:
 code = load_code(codename)
 
 options = {
-    "queue_name": "debug",
+#    "queue_name": "debug",
     "max_wallclock_seconds": 1700,
     "resources": {
         "num_machines": 1,

--- a/aiida_siesta/examples/plugins/siesta/example_molecule.py
+++ b/aiida_siesta/examples/plugins/siesta/example_molecule.py
@@ -43,7 +43,7 @@ except IndexError:
 code = load_code(codename)
 
 options = {
-    "queue_name": "debug",
+#    "queue_name": "debug",
     "max_wallclock_seconds": 1700,
 #    'withmpi': True,
     "resources": {

--- a/aiida_siesta/examples/plugins/siesta/example_psf_family.py
+++ b/aiida_siesta/examples/plugins/siesta/example_psf_family.py
@@ -45,7 +45,7 @@ except IndexError:
 code = load_code(codename)
 
 options = {
-    "queue_name": "debug",
+#    "queue_name": "debug",
     "max_wallclock_seconds": 1700,
     "resources": {
         "num_machines": 1,

--- a/aiida_siesta/examples/plugins/siesta/example_psml.py
+++ b/aiida_siesta/examples/plugins/siesta/example_psml.py
@@ -46,7 +46,7 @@ except IndexError:
 code = load_code(codename)
 
 options = {
-    "queue_name": "debug",
+#    "queue_name": "debug",
     "max_wallclock_seconds": 1700,
     "resources": {
         "num_machines": 1,

--- a/aiida_siesta/parsers/siesta.py
+++ b/aiida_siesta/parsers/siesta.py
@@ -7,19 +7,20 @@ from aiida.orm import Dict
 from six.moves import range
 from aiida.common import OutputParsingError
 from aiida.common import exceptions
-
 # See the LICENSE.txt and AUTHORS.txt files.
 
 # TODO Get modules metadata from setup script.
 
-# These auxiliary functions should be put in another module...
 # List of scalar values from CML to be transferred to AiiDA
-#
 standard_output_list = [
     'siesta:FreeE', 'siesta:E_KS', 'siesta:Ebs', 'siesta:E_Fermi',
     'siesta:stot'
 ]  ## leave svec for later
 
+#####################################################
+# BEGINNING OF SET OF AUXILIARY FUNCTIONS           #
+# They should probably be put in a separate module  #
+#####################################################
 
 def text_to_array(s, dtype):
     return np.array(s.replace("\n", "").split(), dtype=dtype)
@@ -263,27 +264,115 @@ def get_final_forces_and_stress(xmldoc):
 
     return forces, stress
 
+##################################
+# END OF AUXILIARY FUNCTIONS SET #
+##################################
 
-#----------------------------------------------------------------------
 
 from aiida.common.exceptions import OutputParsingError
-
 
 class SiestaOutputParsingError(OutputParsingError):
     pass
 
-
 class SiestaCMLParsingError(OutputParsingError):
     pass
-
-
-#---------------------------
-
 
 class SiestaParser(Parser):
     """
     Parser for the output of Siesta.
     """
+    def parse(self, **kwargs):
+        """
+        Receives in input a dictionary of retrieved nodes.
+        Does all the logic here.
+        """
+        from aiida.engine import ExitCode
+
+        try:
+            output_folder = self.retrieved
+        except exceptions.NotExistent:
+            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
+
+        output_path, messages_path, xml_path, json_path, bands_path = \
+            self._fetch_output_files(output_folder)
+
+        out_results = self._get_output_nodes(output_path, messages_path,
+                                             xml_path, json_path, bands_path)
+
+        for line in out_results["warnings"]:
+            if u'GEOM_NOT_CONV' in line:
+                return (self.exit_codes.GEOM_NOT_CONV)
+            if u'SCF_NOT_CONV' in line:
+                return (self.exit_codes.SCF_NOT_CONV)
+
+        return ExitCode(0)
+
+    def _fetch_output_files(self, out_folder):
+        """
+        Checks the output folder for standard output and standard error
+        files, returns their absolute paths on success.
+
+        :param retrieved: A dictionary of retrieved nodes, as obtained from the
+          parser.
+        """
+        # from aiida.common.datastructures import calc_states
+        from aiida.common.exceptions import InvalidOperation
+        import os
+
+        list_of_files = out_folder._repository.list_object_names()
+
+        output_path = None
+        messages_path = None
+        xml_path = None
+        json_path = None
+        bands_path = None
+
+        if self.node.get_option('output_filename') in list_of_files:
+            output_path = os.path.join(
+                out_folder._repository._get_base_folder().abspath,
+                self.node.get_option('output_filename'))
+        else:
+            raise OutputParsingError("Output file not retrieved")
+
+        if self.node.process_class._DEFAULT_XML_FILE in list_of_files:
+            xml_path = os.path.join(
+                out_folder._repository._get_base_folder().abspath,
+                self.node.process_class._DEFAULT_XML_FILE)
+        else:
+            raise OutputParsingError("Xml file not retrieved")
+
+        if self.node.process_class._DEFAULT_JSON_FILE in list_of_files:
+            json_path = os.path.join(
+                out_folder._repository._get_base_folder().abspath,
+                self.node.process_class._DEFAULT_JSON_FILE)
+#        else:
+#            raise OutputParsingError("json file not retrieved")
+
+        if self.node.process_class._DEFAULT_MESSAGES_FILE in list_of_files:
+            messages_path = os.path.join(
+                out_folder._repository._get_base_folder().abspath,
+                self.node.process_class._DEFAULT_MESSAGES_FILE)
+#        else:
+#            raise OutputParsingError("message file not retrieved")
+
+        if self.node.process_class._DEFAULT_BANDS_FILE in list_of_files:
+            bands_path = os.path.join(
+                out_folder._repository._get_base_folder().abspath,
+                self.node.process_class._DEFAULT_BANDS_FILE)
+
+        if bands_path is None:
+            supposed_to_have_bandsfile = True
+            try:
+                self.node.inputs.bandskpoints
+            except:
+                supposed_to_have_bandsfile = False
+            if supposed_to_have_bandsfile:
+                raise OutputParsingError("bands file not retrieved")
+
+        return output_path, messages_path, xml_path, json_path, bands_path
+
+
+
     def _get_output_nodes(self, output_path, messages_path, xml_path,
                           json_path, bands_path):
         """
@@ -293,7 +382,7 @@ class SiestaParser(Parser):
         from aiida.orm import TrajectoryData
         import re
 
-        parser_version = 'aiida-1.0.0--plugin-1.0.0'
+        parser_version = '1.0.0'
         parser_info = {}
         parser_info['parser_info'] = 'AiiDA Siesta Parser V. {}'.format(
             parser_version)
@@ -386,98 +475,6 @@ class SiestaParser(Parser):
 
         return result_dict
 
-    # def parse(self,retrieved_temporary_folder, **kwargs):
-    def parse(self, **kwargs):
-        """
-        Receives in input a dictionary of retrieved nodes.
-        Does all the logic here.
-        """
-        from aiida.engine import ExitCode
-
-        try:
-            output_folder = self.retrieved
-        except exceptions.NotExistent:
-            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
-
-        output_path, messages_path, xml_path, json_path, bands_path = \
-            self._fetch_output_files(output_folder)
-
-        out_results = self._get_output_nodes(output_path, messages_path,
-                                             xml_path, json_path, bands_path)
-
-        for line in out_results["warnings"]:
-            if u'GEOM_NOT_CONV' in line:
-                return (self.exit_codes.GEOM_NOT_CONV)
-            if u'SCF_NOT_CONV' in line:
-                return (self.exit_codes.SCF_NOT_CONV)
-
-        return ExitCode(0)
-
-    def _fetch_output_files(self, out_folder):
-        """
-        Checks the output folder for standard output and standard error
-        files, returns their absolute paths on success.
-
-        :param retrieved: A dictionary of retrieved nodes, as obtained from the
-          parser.
-        """
-        # from aiida.common.datastructures import calc_states
-        from aiida.common.exceptions import InvalidOperation
-        import os
-
-        list_of_files = out_folder._repository.list_object_names()
-
-        output_path = None
-        messages_path = None
-        xml_path = None
-        json_path = None
-        bands_path = None
-
-        if self.node.get_option('output_filename') in list_of_files:
-            output_path = os.path.join(
-                out_folder._repository._get_base_folder().abspath,
-                self.node.get_option('output_filename'))
-        else:
-            raise OutputParsingError("Output file not retrieved")
-
-        if self.node.get_option('xml_file') in list_of_files:
-            xml_path = os.path.join(
-                out_folder._repository._get_base_folder().abspath,
-                self.node.get_option('xml_file'))
-        else:
-            raise OutputParsingError("Xml file not retrieved")
-
-        if self.node.get_option('json_file') in list_of_files:
-            json_path = os.path.join(
-                out_folder._repository._get_base_folder().abspath,
-                self.node.get_option('json_file'))
-#        else:
-#            raise OutputParsingError("json file not retrieved")
-
-        if self.node.get_option('messages_file') in list_of_files:
-            messages_path = os.path.join(
-                out_folder._repository._get_base_folder().abspath,
-                self.node.get_option('messages_file'))
-
-
-#        else:
-#            raise OutputParsingError("message file not retrieved")
-
-        if self.node.get_option('bands_file') in list_of_files:
-            bands_path = os.path.join(
-                out_folder._repository._get_base_folder().abspath,
-                self.node.get_option('bands_file'))
-
-        if bands_path is None:
-            supposed_to_have_bandsfile = True
-            try:
-                self.node.inputs.bandskpoints
-            except:
-                supposed_to_have_bandsfile = False
-            if supposed_to_have_bandsfile:
-                raise OutputParsingError("bands file not retrieved")
-
-        return output_path, messages_path, xml_path, json_path, bands_path
 
     def get_warnings_from_file(self, messages_path):
         """

--- a/setup.json
+++ b/setup.json
@@ -12,22 +12,22 @@
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
 	"Programming Language :: Python :: 3.6",
-        "Development Status :: 4 - Beta"
+	"Programming Language :: Python :: 3.7",
+	"Development Status :: 4 - Beta"
     ],
     "install_requires": [
         "aiida_core[atomic_tools]>=1.0.0b6,<2.0.0"
     ],
     "extras_require": {
         "dev": [
-            "pre-commit",
-            "prospector==1.1.5",
+            "pre-commit==1.17.0",
+            "prospector==1.1.7",
             "pylint==1.9.4; python_version<'3.0'",
-            "pylint==2.2.2; python_version>='3.0'",
-            "astroid==2.1.0; python_version>='3.0'",
+            "pylint==2.3.1; python_version>='3.0'",
             "pgtest==1.2.0",
             "pytest==3.6.3",
-            "pytest-regressions==1.0.5",
-            "yapf==0.26.0"
+            "pytest-regressions==1.0.6",
+            "yapf==0.28.0"
         ],
         "docs": [
             "Sphinx",


### PR DESCRIPTION
During tests I realized an inconsistency in the structure of the plugin.
aiida.xml aiida.bands MESSAGES and json.time were defined as
spec.inp, but they shouldn't be exposed to the choice
of the user, in fact siesta produces them with a fixed name.
Therefore now they are just class variables _DEFAULT_
I modified the parser accordingly to get the correct names.

Also rearranged the parser to make it more readable and 
commented one option in some examples that might confuse the users.