### PR TITLE
Metadata small fix

### DIFF
--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -52,7 +52,6 @@ class SiestaCalculation(CalcJob):
     _aiida_blocked_keywords.append('dmusesavedm')
     _PSEUDO_SUBFOLDER = './'
     _OUTPUT_SUBFOLDER = './'
-    _PREFIX = 'aiida'
     _DEFAULT_XML_FILE = 'aiida.xml'
     _DEFAULT_JSON_FILE = 'time.json'
     _DEFAULT_MESSAGES_FILE = 'MESSAGES'
@@ -61,6 +60,7 @@ class SiestaCalculation(CalcJob):
 
     # Default of the input.spec, it's just default, but user
     # could change the name
+    _PREFIX = 'aiida'
     _DEFAULT_INPUT_FILE = 'aiida.fdf'
     _DEFAULT_OUTPUT_FILE = 'aiida.out'
 
@@ -113,15 +113,15 @@ class SiestaCalculation(CalcJob):
         # as a separate node, but attached to `CalcJobNode`
         # as attributes. They are optional, since a default is 
         # specified, but they might be changed by the user.
-        spec.input('metadata.options.input_filename',
+        # The first one is siesta specific. The other three
+        # are defined in the CalcJob, here we need just to change
+        # the default.
+        spec.input('metadata.options.prefix',
                    valid_type=six.string_types,
-                   default=cls._DEFAULT_INPUT_FILE)
-        spec.input('metadata.options.output_filename',
-                   valid_type=six.string_types,
-                   default=cls._DEFAULT_OUTPUT_FILE)
-        spec.input('metadata.options.parser_name',
-                   valid_type=six.string_types,
-                   default='siesta.parser')
+                   default=cls._PREFIX)
+        spec.inputs['metadata']['options']['input_filename'].default=cls._DEFAULT_INPUT_FILE
+        spec.inputs['metadata']['options']['output_filename'].default=cls._DEFAULT_OUTPUT_FILE
+        spec.inputs['metadata']['options']['parser_name'].default='siesta.parser'
 
         # Output nodes
         spec.output('output_parameters',
@@ -252,8 +252,8 @@ class SiestaCalculation(CalcJob):
                         "input parameters".format(
                             input_params.get_last_key(key)))
 
-        input_params.update({'system-name': self._PREFIX})
-        input_params.update({'system-label': self._PREFIX})
+        input_params.update({'system-name': self.inputs.metadata.options.prefix})
+        input_params.update({'system-label': self.inputs.metadata.options.prefix})
         input_params.update({'use-tree-timer': 'T'})
         input_params.update({'xml-write': 'T'})
         input_params.update({'number-of-species': len(structure.kinds)})

--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -52,15 +52,13 @@ class SiestaCalculation(CalcJob):
     _aiida_blocked_keywords.append('dmusesavedm')
     _PSEUDO_SUBFOLDER = './'
     _OUTPUT_SUBFOLDER = './'
-    _DEFAULT_XML_FILE = 'aiida.xml'
-    _DEFAULT_JSON_FILE = 'time.json'
-    _DEFAULT_MESSAGES_FILE = 'MESSAGES'
-    _DEFAULT_BANDS_FILE = 'aiida.bands'
+    _JSON_FILE = 'time.json'
+    _MESSAGES_FILE = 'MESSAGES'
 
 
     # Default of the input.spec, it's just default, but user
     # could change the name
-    _PREFIX = 'aiida'
+    _DEFAULT_PREFIX = 'aiida'
     _DEFAULT_INPUT_FILE = 'aiida.fdf'
     _DEFAULT_OUTPUT_FILE = 'aiida.out'
 
@@ -118,7 +116,7 @@ class SiestaCalculation(CalcJob):
         # the default.
         spec.input('metadata.options.prefix',
                    valid_type=six.string_types,
-                   default=cls._PREFIX)
+                   default=cls._DEFAULT_PREFIX)
         spec.inputs['metadata']['options']['input_filename'].default=cls._DEFAULT_INPUT_FILE
         spec.inputs['metadata']['options']['output_filename'].default=cls._DEFAULT_OUTPUT_FILE
         spec.inputs['metadata']['options']['parser_name'].default='siesta.parser'
@@ -506,12 +504,14 @@ class SiestaCalculation(CalcJob):
         # messages file, and the json timing file.
         # If bandskpoints, also the bands file is added to the retrieve list.
         calcinfo.retrieve_list = []
+        _XML_FILE = str(metadataoption.prefix) + ".xml"
+        _BANDS_FILE = str(metadataoption.prefix) + ".bands"
         calcinfo.retrieve_list.append(metadataoption.output_filename)
-        calcinfo.retrieve_list.append(self._DEFAULT_XML_FILE) 
-        calcinfo.retrieve_list.append(self._DEFAULT_JSON_FILE) 
-        calcinfo.retrieve_list.append(self._DEFAULT_MESSAGES_FILE) 
+        calcinfo.retrieve_list.append(_XML_FILE) 
+        calcinfo.retrieve_list.append(self._JSON_FILE) 
+        calcinfo.retrieve_list.append(self._MESSAGES_FILE) 
         if bandskpoints is not None:
-            calcinfo.retrieve_list.append(self._DEFAULT_BANDS_FILE) 
+            calcinfo.retrieve_list.append(_BANDS_FILE) 
         # Any other files specified in the settings dictionary
         settings_retrieve_list = settings_dict.pop('ADDITIONAL_RETRIEVE_LIST',
                                                    [])

--- a/aiida_siesta/parsers/siesta.py
+++ b/aiida_siesta/parsers/siesta.py
@@ -333,31 +333,35 @@ class SiestaParser(Parser):
         else:
             raise OutputParsingError("Output file not retrieved")
 
-        if self.node.process_class._DEFAULT_XML_FILE in list_of_files:
+        namexmlfile = str(self.node.get_option('prefix')) + ".xml"
+        print(namexmlfile)
+        print(list_of_files)
+        if namexmlfile in list_of_files:
             xml_path = os.path.join(
                 out_folder._repository._get_base_folder().abspath,
-                self.node.process_class._DEFAULT_XML_FILE)
+                namexmlfile)
         else:
             raise OutputParsingError("Xml file not retrieved")
 
-        if self.node.process_class._DEFAULT_JSON_FILE in list_of_files:
+        if self.node.process_class._JSON_FILE in list_of_files:
             json_path = os.path.join(
                 out_folder._repository._get_base_folder().abspath,
-                self.node.process_class._DEFAULT_JSON_FILE)
+                self.node.process_class._JSON_FILE)
 #        else:
 #            raise OutputParsingError("json file not retrieved")
 
-        if self.node.process_class._DEFAULT_MESSAGES_FILE in list_of_files:
+        if self.node.process_class._MESSAGES_FILE in list_of_files:
             messages_path = os.path.join(
                 out_folder._repository._get_base_folder().abspath,
-                self.node.process_class._DEFAULT_MESSAGES_FILE)
+                self.node.process_class._MESSAGES_FILE)
 #        else:
 #            raise OutputParsingError("message file not retrieved")
 
-        if self.node.process_class._DEFAULT_BANDS_FILE in list_of_files:
+        namebandsfile = str(self.node.get_option('prefix')) + ".bands"
+        if namebandsfile in list_of_files:
             bands_path = os.path.join(
                 out_folder._repository._get_base_folder().abspath,
-                self.node.process_class._DEFAULT_BANDS_FILE)
+                namebandsfile)
 
         if bands_path is None:
             supposed_to_have_bandsfile = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,7 @@ def generate_calc_job_node():
         node = orm.CalcJobNode(computer=computer, process_type=entry_point)
         node.set_attribute('input_filename', 'aiida.fdf')
         node.set_attribute('output_filename', 'aiida.out')
-        #node.set_attribute('xml_file', 'aiida.xml')
+        node.set_attribute('prefix', 'aiida')
         node.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
         node.set_option('max_wallclock_seconds', 1800)
 


### PR DESCRIPTION
The "system-label" of a siesta calculation determines the name of the files produced by the code (except the output file). For instance the files containing the bands and the DOS are named respectively system-labe.bands, system-labe.DOS. So far "system-label" was hard coded to be "aiida" for any siesta calculation run through aiida_siesta. Moreover its value was not stored anywhere. Now a keyword "prefix" is added to the "metadata.options" (with default value "aiida") and its value determines the "system-label" of the siesta calculation. This allows, in case (but not suggested), to modify through aiida the  "system-label", and, more importantly, this value is stored as an attribute of the SiestaCalculation, making easier the post process of siesta produced files through aiida plugins (see the STM plugin as an example).
Also, a modification in the spec.input of some metadata.option is introduced. In fact some standards (like metadata.options.inputfile_name) are inherited  from CalcJob. Therefore there is no need to redefine them, a change in the default is sufficient.