### PR TITLE
Little revamping of siesta parser, fixes also a corner case bug.

### DIFF
--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -106,7 +106,7 @@ class SiestaCalculation(CalcJob):
         spec.default_output_node = 'output_parameters'
 
         # Error handeling
-        spec.exit_code(100, 'ERROR_NO_RETRIEVED_FOLDER', message='Retrieved-folder data node could not be accessed.')
+        spec.exit_code(140, 'BANDS_FILE_NOT_PRODUCED', message='Bands analysis was requested, but file is not present')
         spec.exit_code(120, 'SCF_NOT_CONV', message='Calculation did not reach scf convergence!')
         spec.exit_code(130, 'GEOM_NOT_CONV', message='Calculation did not reach geometry convergence!')
 

--- a/tests/parsers/test_siesta/test_siesta_bandspoints.yml
+++ b/tests/parsers/test_siesta/test_siesta_bandspoints.yml
@@ -32,7 +32,6 @@ output_parameters:
   nnz: 19594
   no_u: 26
   parser_info: AiiDA Siesta Parser V. 1.0.1
-  parser_warnings: []
   siesta:Arch: gfortran-esl-bundle-0.4
   siesta:EndTime: 2020-01-07T14-53-55
   siesta:Flags: 'mpif90 -O2 -fbacktrace '

--- a/tests/parsers/test_siesta/test_siesta_default.yml
+++ b/tests/parsers/test_siesta/test_siesta_default.yml
@@ -22,7 +22,6 @@ output_parameters:
   nnz: 19594
   no_u: 26
   parser_info: AiiDA Siesta Parser V. 1.0.1
-  parser_warnings: []
   siesta:Arch: gfortran-esl-bundle-0.4
   siesta:EndTime: 2020-01-07T11-59-44
   siesta:Flags: 'mpif90 -O2 -fbacktrace '


### PR DESCRIPTION
The siesta parser has been simplified in order to make it more
readable and facilitate future improvements in the error management.
Also a small bug has been corrected. In the previous parser version,
the presence of the bands_file was checked before the MESSAGES file
analysis. Therefore in the situation of not scf convergence, the
process was excepted because of missing bands_file. However this is not
desired, we want the parser to check first if there is convergence.
If the calculation is converged, then we check if the bands_file is
present.