### PR TITLE
Fix data

### DIFF
--- a/aiida_siesta/commands/data_psf.py
+++ b/aiida_siesta/commands/data_psf.py
@@ -55,22 +55,14 @@ def psf_listfamilies(elements, with_description):
     """
     from aiida import orm
     from aiida.plugins import DataFactory
-    from aiida_siesta.data.psf import PSFGROUP_TYPE
+    from aiida_siesta.groups.pseudos import PsfFamily
 
     PsfData = DataFactory('siesta.psf')  # pylint: disable=invalid-name
     query = orm.QueryBuilder()
     query.append(PsfData, tag='psfdata')
     if elements is not None:
         query.add_filter(PsfData, {'attributes.element': {'in': elements}})
-    query.append(
-        orm.Group,
-        with_node='psfdata',
-        tag='group',
-        project=['label', 'description'],
-        filters={'type_string': {
-            '==': PSFGROUP_TYPE
-        }}
-    )
+    query.append(PsfFamily, with_node='psfdata', tag='group', project=['label', 'description'])
 
     query.distinct()
     if query.count() > 0:

--- a/aiida_siesta/commands/data_psml.py
+++ b/aiida_siesta/commands/data_psml.py
@@ -55,22 +55,14 @@ def psml_listfamilies(elements, with_description):
     """
     from aiida import orm
     from aiida.plugins import DataFactory
-    from aiida_siesta.data.psml import PSMLGROUP_TYPE
+    from aiida_siesta.groups.pseudos import PsmlFamily
 
     PsmlData = DataFactory('siesta.psml')  # pylint: disable=invalid-name
     query = orm.QueryBuilder()
     query.append(PsmlData, tag='psmldata')
     if elements is not None:
         query.add_filter(PsmlData, {'attributes.element': {'in': elements}})
-    query.append(
-        orm.Group,
-        with_node='psmldata',
-        tag='group',
-        project=['label', 'description'],
-        filters={'type_string': {
-            '==': PSMLGROUP_TYPE
-        }}
-    )
+    query.append(PsmlFamily, with_node='psmldata', tag='group', project=['label', 'description'])
 
     query.distinct()
     if query.count() > 0:

--- a/aiida_siesta/data/psml.py
+++ b/aiida_siesta/data/psml.py
@@ -329,8 +329,13 @@ class PsmlData(SinglefileData):
         Get the list of all psml family names to which the pseudo belongs
         """
         from aiida.orm import Group
+        from aiida.orm import QueryBuilder
 
-        return [_.name for _ in Group.query(nodes=self, type_string=self.psmlfamily_type_string)]
+        query = QueryBuilder()
+        query.append(Group, filters={'type_string': {'==': self.psmlfamily_type_string}}, tag='group', project='label')
+        query.append(PsmlData, filters={'id': {'==': self.id}}, with_group='group')
+
+        return [_[0] for _ in query.all()]
 
     @property
     def element(self):
@@ -403,24 +408,23 @@ class PsmlData(SinglefileData):
                for the username (that is, the user email).
         """
         from aiida.orm import Group
+        from aiida.orm import QueryBuilder
+        from aiida.orm import User
 
-        group_query_params = {"type_string": cls.psmlfamily_type_string}
+        query = QueryBuilder()
+        filters = {'type_string': {'==': cls.psmlfamily_type_string}}
 
-        if user is not None:
-            group_query_params['user'] = user
+        query.append(Group, filters=filters, tag='group', project='*')
+
+        if user:
+            query.append(User, filters={'email': {'==': user}}, with_group='group')
 
         if isinstance(filter_elements, str):
             filter_elements = [filter_elements]
 
         if filter_elements is not None:
-            actual_filter_elements = {_.capitalize() for _ in filter_elements}
+            query.append(PsmlData, filters={'attributes.element': {'in': filter_elements}}, with_group='group')
 
-            group_query_params['node_attributes'] = {'element': actual_filter_elements}
+        query.order_by({Group: {'id': 'asc'}})
 
-        all_psml_groups = Group.query(**group_query_params)
-
-        groups = [(g.name, g) for g in all_psml_groups]
-        # Sort by name
-        groups.sort()
-        # Return the groups, without name
-        return [_[1] for _ in groups]
+        return [_[0] for _ in query.all()]

--- a/aiida_siesta/groups/pseudos.py
+++ b/aiida_siesta/groups/pseudos.py
@@ -1,0 +1,8 @@
+from aiida.orm.groups import Group
+
+class PsfFamily(Group):
+    """Group that represents a pseudo potential family containing `PsfData` nodes."""
+
+
+class PsmlFamily(Group):
+    """Group that represents a pseudo potential family containing `PsmlData` nodes."""

--- a/aiida_siesta/groups/pseudos.py
+++ b/aiida_siesta/groups/pseudos.py
@@ -1,5 +1,6 @@
 from aiida.orm.groups import Group
 
+
 class PsfFamily(Group):
     """Group that represents a pseudo potential family containing `PsfData` nodes."""
 

--- a/setup.json
+++ b/setup.json
@@ -55,6 +55,10 @@
         "aiida.cmdline.data": [
             "psf = aiida_siesta.commands.data_psf:psfdata",
             "psml = aiida_siesta.commands.data_psml:psmldata"
-        ]
+        ],
+	"aiida.groups": [
+      	    "data.psf.family = aiida_siesta.groups.pseudos:PsfFamily",
+            "data.psml.family = aiida_siesta.groups.pseudos:PsmlFamily"
+    	]
     }
 }

--- a/tests/data/test_pseudos.py
+++ b/tests/data/test_pseudos.py
@@ -1,0 +1,24 @@
+def test_pseudos_classmethods(generate_psf_data, generate_psml_data):
+
+    from aiida_siesta.data.psml import PsmlData
+    from aiida_siesta.data.psf import PsfData
+
+    assert PsfData.get_psf_groups() == []
+    assert PsmlData.get_psml_groups() == []
+
+    #get_psf_group(cls, group_label)
+
+    #from_md5
+
+    #get_or_create
+
+def test_pseudo(generate_psf_data, generate_psml_data):
+    
+    psf = generate_psf_data('Si')
+    psml = generate_psml_data('Si')
+    
+    assert psf.get_psf_family_names() == []
+    assert psml.get_psml_family_names() == []
+
+    #set_file
+    #assert 'md5' in psf.attributes


### PR DESCRIPTION
From aiida 1.2.0 the class `Group` have been modified to implement new features.
This has implications in our plugin because the PseudoFamilies are Groups.
In particular there is now an explicit implementation of PsmlFamily and PsfFamily
as sub-classes of the `Group` class. Moreover PsmlFamily and PsfFamily are
registered as entry points making possible to reload the correct
sub class when reloading from the database.
For more info see: aiidateam/aiida-core#3882