### PR TITLE
Convergence workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 *.swp
 # C extensions
 *.so
+.env
 
 # distribution build directories
 *.egg-info/

--- a/aiida_siesta/examples/workflows/example_converge_meshcutoff.py
+++ b/aiida_siesta/examples/workflows/example_converge_meshcutoff.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env runaiida
+
+'''
+This is an example of how to converge a parameter using the aiida_siesta
+plugin.
+
+More specifically, we will converge the mesh cutoff here, but you can do the
+same for other parameters/basis parameters/attributes...
+'''
+
+#Not required by AiiDA
+import os.path as op
+import sys
+
+#AiiDA classes and functions
+from aiida.orm import load_code
+from aiida.orm import Float, Dict, StructureData, KpointsData
+from aiida_siesta.data.psf import PsfData
+from aiida_siesta.workflows.converge import converge
+
+'''
+First of all, we need to setup all the inputs of the calculations.
+
+See https://aiida-siesta-plugin.readthedocs.io/en/stable/workflows/base.html#inputs.
+
+Basically, we will build an "inputs" dict at the end of the file, and all we are doing until
+there is to build every part of it step by step.
+
+All this is general to any SIESTA calculation with AiiDa, so if you already know how it works,
+go to the end of the file, where we really do the convergence specific stuff.
+'''
+
+# Load the version of siesta that we are going to use
+try:
+    codename = sys.argv[1]
+except IndexError:
+    codename = 'Siesta-4.0.2@kay'
+code = load_code(codename)
+
+# Generate the structure (or get it from somewhere else)
+try:
+    # We can get it using sisl (useful if we have it in an *fdf, *XV, ...)
+    import sisl
+    
+    ase_struct = sisl.geom.diamond(5.430, 'Si').toASE()
+except:
+    # Or using ASE
+    import ase
+
+    ase_struct = ase.build.bulk('Si', 'diamond', 5.430)
+# Then just pass it to StructureData, which is the type that Aiida works with
+structure = StructureData(ase=ase_struct)
+
+# Specify some parameters that go into the fdf file
+parameters = Dict(
+    dict={
+        'xc-functional': 'LDA',
+        'xc-authors': 'CA',
+        'max-scfiterations': 40,
+        'dm-numberpulay': 4,
+        'dm-mixingweight': 0.3,
+        'dm-tolerance': 1.e-5,
+        'Solution-method': 'diagon',
+        'electronic-temperature': '25 meV',
+    })
+
+# Extra parameters that also go to the fdf file, but are related
+# to the basis.
+basis = Dict(
+    dict={
+        'pao-energy-shift': '300 meV',
+        '%block pao-basis-sizes': """
+Si DZP
+%endblock pao-basis-sizes""",
+    })
+
+# Define the kpoints for the simulations. Note that this is not passed as
+# a normal fdf parameter, it has "its own input"
+kpoints = KpointsData()
+kpoints.set_kpoints_mesh([14, 14, 14])
+
+# Get the appropiate pseudos (in "real life", one could have a pseudos family defined
+# in aiida database with `verdi data psf uploadfamily <path to folder> <family name>`)
+# and then pass it as a simple string, Aiida will know which pseudos to use.
+# See the pseudo_family in the aiida_siesta docs (link on top of the file)
+pseudos_dict = {}
+raw_pseudos = [("Si.psf", ['Si'])]
+for fname, kinds in raw_pseudos:
+    absname = op.realpath(
+        op.join(op.dirname(__file__),
+                "../plugins/siesta/data/sample-psf-family", fname))
+    pseudo, created = PsfData.get_or_create(absname, use_first=True)
+    if created:
+        print("\nCreated the pseudo for {}".format(kinds))
+    else:
+        print("\nUsing the pseudo for {} from DB: {}".format(kinds, pseudo.pk))
+    for j in kinds:
+        pseudos_dict[j] = pseudo
+
+# Options that are related to how the job is technically submitted and
+# run. Some of this options define flags for the job manager (e.g. SLURM)
+# and some other's are related to how the code is executed. Note that 
+# 'max_wallclock_seconds' is a required option, so that SIESTA can stop
+# gracefully before the job runs out of time.
+options = Dict(
+    dict={
+        "max_wallclock_seconds": 360,
+        #'withmpi': True,
+        #'account': "tcphy113c",
+        #'queue_name': "DevQ",
+        "resources": {
+            "num_machines": 1,
+            "num_mpiprocs_per_machine": 1,
+        }
+    })
+
+# Now we have all inputs defined, so as promised at the beggining of the file
+# we build the inputs dicts to pass it to the process. There's no need though,
+# we could pass each input separately. This is just so that the process call
+# looks cleaner.
+inputs = {
+    'structure': structure,
+    'parameters': parameters,
+    'code': code,
+    'basis': basis,
+    'kpoints': kpoints,
+    'pseudos': pseudos_dict,
+    'options': options,
+}
+
+# Up until this point, all the things done have been general to any SIESTA
+# simulation. Now, we will use the converge API to launch an aiida job for us.
+# We need to pass the parameter we want to converge, in this case 'meshcutoff'
+# and the inputs. In this case we also pass de call_method, because the default is
+# run, and we want to use submit (these are the two AiiDa ways of executing a
+# calculation).
+process = converge('meshcutoff', call_method='submit', **inputs)
+
+'''
+It is this simple because meshcutoff has some default iteration (start with 100 Ry,
+increment by 100 each time), but converge is not really more than
+submit(ConvergengeWorkflow, **inputs), so you can pass all the inputs that the
+convergence workflow accepts.
+
+For example:
+
+process = converge('meshcutoff', call_method='submit', **inputs, init_value=100, step=100, steps=15,
+    target='E_KS', threshold=0.01)
+
+Note that the iterate API in aiida_siesta.workflows.iterate.iterate works exactly the same
+(in fact converge is just an extension of iterate), so if you know how to converge, you know
+how to iterate, and viceversa :)
+'''
+
+# Print some info
+print("Submitted workchain; ID={}".format(process.pk))
+print(
+    "For information about this workchain type: verdi process show {}".format(
+        process.pk))
+print("For a list of running processes type: verdi process list")

--- a/aiida_siesta/examples/workflows/example_convergence.py
+++ b/aiida_siesta/examples/workflows/example_convergence.py
@@ -16,7 +16,7 @@ import sys
 # AiiDA classes and functions
 from aiida.engine import submit
 from aiida.orm import load_code
-from aiida.orm import Float, Dict, StructureData, Str
+from aiida.orm import Float, Dict, StructureData, Str, Int
 from aiida_siesta.data.psf import PsfData
 # The workchain that we are going to use to converge things.
 from aiida_siesta.workflows.converge import SiestaSequentialConverger
@@ -134,7 +134,7 @@ inputs = {
 # to iterate_over. Each dictionary will be passed to the "iterate_over" input of the
 # SiestaConverger (which works exactly like the SiestaIterator). Therefore, each
 # dictionary contains information about what needs to be converged. 
-process = submit(SiestaSequentialConverger, **inputs,
+process = submit(SiestaSequentialConverger,
     iterate_over=[
         # First we want to converge the kpoints by increasing all components
         # at the same time.
@@ -155,10 +155,18 @@ process = submit(SiestaSequentialConverger, **inputs,
         # Note that we can converge the same parameters again if we wanted,
         # so we could do another round of k point convergence here.
     ],
-    # These are the defaults target and threshold, but we are going
-    # to pass them here to make it clear that this can be tuned.
-    target=Str('E_KS'),
-    threshold=Float(0.01)
+    # And now we are passing the inputs for the converger:
+    converger_inputs={
+        # All the general inputs for the siesta simulation
+        **inputs,
+        # These are the defaults target and threshold, but we are going
+        # to pass them here to make it clear that this can be tuned.
+        "target": Str('E_KS'),
+        "threshold": Float(0.01),
+        # And we also specify a batch size to submit more than one job at a time
+        "batch_size": Int(3)
+    }
+    
 )
 
 # Print some info

--- a/aiida_siesta/workflows/converge.py
+++ b/aiida_siesta/workflows/converge.py
@@ -4,7 +4,8 @@ from aiida.engine import WorkChain, calcfunction, while_, ToContext
 from aiida.orm import Float, Str, List, KpointsData, Bool, Int
 from aiida.common import AttributeDict
 
-from .iterate import BaseIteratorWorkChain ,ParameterIterator, BasisParameterIterator, AttributeIterator, get_iterator_and_defaults
+from .iterate import BaseIteratorWorkChain ,ParameterIterator, BasisParameterIterator,  \
+                AttributeIterator, KpointComponentIterator, get_iterator_and_defaults
 
 @calcfunction
 def generate_convergence_results(variable_values, target_values, converged):
@@ -37,7 +38,7 @@ def generate_new_kpoints(old_kpoints, component, val):
 
     return new_kpoints
 
-class BaseConvergence(BaseIteratorWorkChain):
+class BaseConvergenceWorkchain(BaseIteratorWorkChain):
     '''
     General workflow that finds the converged value for a parameter.
 
@@ -98,7 +99,6 @@ class BaseConvergence(BaseIteratorWorkChain):
 
         self.ctx.target_values.append(simulation_outputs[self.inputs.target.value])
 
-
     def return_results(self):
         '''
         Takes care of returning the results of the workchain to the user
@@ -116,16 +116,17 @@ class BaseConvergence(BaseIteratorWorkChain):
         self.out('attempted_values', variable_values)
         self.out('target_values', target_values)
 
-class ParameterConvergence(BaseConvergence, ParameterIterator):
+class ParameterConvergence(BaseConvergenceWorkchain, ParameterIterator):
     pass
 
-class BasisParameterConvergence(BaseConvergence, BasisParameterIterator):
+class BasisParameterConvergence(BaseConvergenceWorkchain, BasisParameterIterator):
     pass
 
-class AttributeConvergence(BaseConvergence, AttributeIterator):
+class AttributeConvergence(BaseConvergenceWorkchain, AttributeIterator):
     pass
 
-
+class KpointComponentConvergence(BaseConvergenceWorkchain, KpointComponentIterator):
+    pass
 
 class KpointsConvergence(WorkChain):
         

--- a/aiida_siesta/workflows/converge.py
+++ b/aiida_siesta/workflows/converge.py
@@ -170,12 +170,16 @@ class SequentialConverger(InputIterator):
     '''
 
     _process_class = None
-    _expose_inputs_kwargs = {'exclude': ("iterate_over",)}
+    _expose_inputs_kwargs = {'exclude': ("iterate_over",), "namespace": 'converger_inputs'}
     _reuse_inputs = True
 
     @classmethod
     def define(cls, spec):
         super().define(spec)
+
+        # In principle we should not allow to provide a batch size and we should force a value of 1
+        # But I don't know how to do it in a clean way.
+        spec.inputs.ports['batch_size'].default = lambda: Int(1)
 
         spec.output(
             'converged_parameters',

--- a/aiida_siesta/workflows/converge.py
+++ b/aiida_siesta/workflows/converge.py
@@ -1,0 +1,253 @@
+import numpy as np
+
+from aiida.engine import WorkChain, calcfunction, while_, ToContext
+from aiida.orm import Float, Str, List, KpointsData, Bool, Int
+from aiida.common import AttributeDict
+
+from .iterate import BaseIteratorWorkChain ,ParameterIterator, BasisParameterIterator, AttributeIterator, get_iterator_and_defaults
+
+@calcfunction
+def generate_convergence_results(variable_values, target_values, converged):
+    '''
+    Generates the final output of the convergence workflows.
+    '''
+
+    convergence_results = {
+        'converged': Bool(converged),
+    }
+
+    if converged:
+        final_value = variable_values[-2]
+        dtype = {str: Str, int: Int, float: Float}[type(final_value)]
+
+        convergence_results['final_value'] = dtype(final_value)
+        convergence_results['final_target_value'] = Float(target_values[-2])
+
+    return convergence_results
+
+@calcfunction
+def generate_new_kpoints(old_kpoints, component, val):
+
+    mesh, offset = old_kpoints.get_kpoints_mesh()
+
+    mesh[component.value] = val
+
+    new_kpoints = KpointsData()
+    new_kpoints.set_kpoints_mesh(mesh, offset)
+
+    return new_kpoints
+
+class BaseConvergence(BaseIteratorWorkChain):
+    '''
+    General workflow that finds the converged value for a parameter.
+
+    There is no specificity in what should be converged or which parameter
+    should be varied.
+    '''
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+
+        # The outline is defined by Iterator workflow, and most of the inputs too.
+        # Threshold is an input that is specific to a convergence workflow.
+        spec.input(
+            "threshold",
+            valid_type=(Int,Float),
+            required=True,
+            default=lambda: Float(0.01),
+            help="The maximum difference between two consecutive steps to consider that convergence is reached"
+        )
+
+        spec.output('converged',
+            help="Whether the target has converged"
+        )
+        spec.output('final_value',
+            help="The value for the variable that was enough to achieve convergence. "
+            "Otherwise, this value makes no sense."
+        )
+        spec.output('final_target_value',
+            help="The value of the target with convergence reached."
+        )
+        spec.output('attempted_values')
+        spec.output('target_values')
+
+    @property
+    def converged(self):
+        '''
+        Checks if the target property has already converged.
+        '''
+        target_values = self.ctx.target_values
+
+        if len(target_values) <= 1:
+            return False
+        else:
+            converged = abs(target_values[-2] - target_values[-1]) < self.inputs.threshold.value
+            self.report(f'Convergence criterium: {self.inputs.threshold.value}; Current diff: {abs(target_values[-2] - target_values[-1])}')
+            return converged
+
+    @property
+    def should_proceed(self):
+        return not self.converged
+    
+    def process_calc(self):
+        # Append the value of the target property for the last run
+        results = self.ctx.calculation.outputs
+
+        simulation_outputs = results.output_parameters.get_dict()
+
+        self.ctx.target_values.append(simulation_outputs[self.inputs.target.value])
+
+
+    def return_results(self):
+        '''
+        Takes care of returning the results of the workchain to the user
+        '''
+
+        converged = Bool(self.converged)
+        variable_values = List(list=self.ctx.variable_values)
+        target_values = List(list=self.ctx.target_values)
+        
+        # Return the convergence results
+        self.out_many(generate_convergence_results(variable_values, target_values, converged))
+
+        # And the 'log' of the process (this nodes have already been registered because
+        # they are inputs of generate_convergence_results, which is a calcfunction)
+        self.out('attempted_values', variable_values)
+        self.out('target_values', target_values)
+
+class ParameterConvergence(BaseConvergence, ParameterIterator):
+    pass
+
+class BasisParameterConvergence(BaseConvergence, BasisParameterIterator):
+    pass
+
+class AttributeConvergence(BaseConvergence, AttributeIterator):
+    pass
+
+
+
+class KpointsConvergence(WorkChain):
+        
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+
+        # Define the outline of the workflow, i.e. the order in which methods
+        # should be executed
+        spec.outline(
+            cls.initialize,
+            while_(cls.next_kpoint)(
+                cls.find_convergence,
+                cls.process_convergence_results,
+            ),
+            cls.return_results
+        )
+
+        # Define all the inputs that this workchain expects
+
+        # Inputs related to the variable parameter
+        spec.input(
+            "order",
+            valid_type=List,
+            required=False,
+            default=lambda: List(list=[0,1,2]),
+            help="The order in which the kpoint components should be converged."
+        )
+        
+        spec.expose_inputs(KpointComponentConvergence, exclude=('component',))
+        spec.inputs._ports['pseudos'].dynamic = True
+        
+        # Define what are the outputs that this workchain will return
+        spec.output('converged_kpoints',
+            help="The kpoints with all components converged"
+        )
+        spec.output('final_target_value')
+    
+    def initialize(self):
+
+        self.ctx.convergence_inputs = AttributeDict(self.exposed_inputs(KpointComponentConvergence))
+
+        self.ctx.kpoints = KpointsData()
+        init_value = self.ctx.convergence_inputs.init_value
+
+        self.ctx.kpoints.set_kpoints_mesh([init_value.value]*3)
+
+        self.ctx.left_to_converge = self.inputs.order.get_list()
+
+    def next_kpoint(self):
+        '''
+        Checks if there are components left to converge.
+
+        If there are, prepares things for next step
+        '''
+
+        if len(self.ctx.left_to_converge) == 0:
+            return False
+
+        self.ctx.component = self.ctx.left_to_converge.pop(0)
+
+        self.report(f'Starting to converge kpoint component {self.ctx.component}')
+
+        return True
+        
+    def find_convergence(self):
+        '''
+        Executes the corresponding convergence workflow
+        '''
+
+        # There are two inputs that are provided by this workflow
+        # the rest are handled by KpointComponentConvergence
+        inputs = {
+            **self.ctx.convergence_inputs,
+            'component': Int(self.ctx.component),
+            'kpoints': self.ctx.kpoints
+        }
+
+        # Run the convergence workflow
+        process = self.submit(KpointComponentConvergence, **inputs)
+
+        # And make the workchain wait for the results
+        return ToContext(last_process=process)
+
+    def process_convergence_results(self):
+
+        convergence_output = self.ctx.last_process.outputs
+
+        if not convergence_output['converged']:
+            raise Exception(f"Component {self.ctx.component} didn't converge")
+
+        # If it did converge, update the kpoints
+        self.report(f'Kpoint component {self.ctx.component} converged at {convergence_output["final_value"].value}')
+        self.ctx.kpoints = generate_new_kpoints(self.ctx.kpoints, Int(self.ctx.component), convergence_output['final_value'])
+
+    def return_results(self):
+
+        self.out('converged_kpoints', self.ctx.kpoints)
+        self.out('final_target_value', self.ctx.last_process.outputs['final_target_value'])
+
+def iterator_to_converger(IteratorClass):
+    
+    for Converger in [ParameterConvergence, BasisParameterConvergence, AttributeConvergence]:
+        if IteratorClass in Converger.__mro__:
+            return Converger
+
+def get_converger_and_defaults(iterate_over):
+
+    Iterator, defaults = get_iterator_and_defaults(iterate_over)
+
+    return iterator_to_converger(Iterator), defaults
+
+def converge(over, *args, call_method='run', **kwargs):
+    from aiida.engine import run, submit
+
+    Converger, defaults = get_converger_and_defaults(over)
+
+    execute = run if call_method is 'run' else submit
+
+    return execute(Converger, *args, **{**defaults, **kwargs})
+
+
+
+
+

--- a/aiida_siesta/workflows/converge.py
+++ b/aiida_siesta/workflows/converge.py
@@ -143,7 +143,8 @@ class BaseConvergencePlugin:
 
         if converged:
             self.report(
-                f'\n\nConvergence has been reached! Converged parameters: {outputs["converged_parameters"].get_dict()}\n'
+                '\n\nConvergence has been reached! Converged parameters:'
+                f'{outputs["converged_parameters"].get_dict()}\n'
             )
         else:
             self.report('\n\nWARNING: Workchain ended without finding convergence\n ')
@@ -185,7 +186,7 @@ class SequentialConverger(InputIterator):
         super().define(spec)
 
         # In this case, iterate_over is going to be a list where each item is a dict as accepted
-        # BaseIterator's regular iterate_over 
+        # BaseIterator's regular iterate_over
         spec.inputs.ports['iterate_over'].valid_type = List
 
         # In principle we should not allow to provide a batch size and we should force a value of 1

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -603,8 +603,8 @@ class InputIterator(BaseIteratorWorkChain):
             for _, parameters_group in self._params_lookup:
 
                 # Check if the parameter is in the group's explicit keys or if it matches a condition.
-                if parameter in parameters_group['keys'].keys() or parameters_group.get("condition",
-                                                                                        lambda p: False)(parameter):
+                in_keys = parameter in parameters_group['keys']
+                if in_keys or parameters_group.get("condition", lambda p: False)(parameter):
 
                     # If it does, get the input key that this parameter is going to modify
                     input_key = parameters_group['input_key']
@@ -664,7 +664,7 @@ def set_up_parameters_dict(val, inputs, parameter, input_key, defaults=None):
     parameters[parameter] = val
 
     # And then just translate it again to a dict to use it in the input
-    return DataFactory('dict')(dict={key: val for key, (val, _) in parameters._storage.items()})
+    return DataFactory('dict')(dict=parameters.get_dict())
 
 
 def set_up_kpoint_grid(val, inputs, parameter, input_key='kpoints'):
@@ -746,14 +746,14 @@ SIESTA_ITERATION_PARAMS = (
             "input_key": "basis",
             "parse_func": set_up_parameters_dict,
             "condition": lambda parameter: FDFDict.translate_key(parameter).startswith("pao"),
-            "keys": FDFDict(
-                paobasissize={'defaults': {
+            "keys": FDFDict({
+                "paobasissize":{'defaults': {
                     'values_list': ['SZ', 'SZP', 'DZ', 'DZP', 'TZ', 'TZP']
                 }},
-                paoenergyshift={'defaults': {
+                "paoenergyshift":{'defaults': {
                     'units': 'Ry'
                 }}
-            )
+            })
         }
     ),
     (
@@ -773,13 +773,13 @@ SIESTA_ITERATION_PARAMS = (
             "input_key": "parameters",
             "condition": lambda parameter: True,
             "parse_func": set_up_parameters_dict,
-            "keys": FDFDict(
-                meshcutoff={'defaults': {
+            "keys": FDFDict({
+                "meshcutoff": {'defaults': {
                     'units': 'Ry',
                     'init_value': 100,
                     'step': 100
                 }}
-            )
+            })
         }
     ),
 )

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -603,7 +603,7 @@ class SiestaIterator(InputIterator):
 
         # Once we have the corresponding dict, we check if the parameter is defined.
         # If it is there, we get the dictionary that defines how it should be used
-        param_info = params_dict["params"][parameter].get(parameter, None)
+        param_info = params_dict["params"].get(parameter, None)
 
         # Try to get its default units
         units = None

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -405,7 +405,7 @@ class InputIterator(BaseIteratorWorkChain):
         super().define(spec)
 
         # We expose the inputs of the workchain that is run at each iteration
-        spec.expose_inputs(cls._process_class, **cls.expose_inputs_kwargs)
+        spec.expose_inputs(cls._process_class, **cls._expose_inputs_kwargs)
 
     def run_process(self):
         '''

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -89,7 +89,7 @@ class BaseIteratorWorkChain(WorkChain, ABC):
             for key, val in iterate_over.items():
                 if not isinstance(val, (list, tuple, np.ndarray)):
                     raise ValueError(
-                        f"We can not understand how to iterate over '{key}', " 
+                        f"We can not understand how to iterate over '{key}', "
                         f"you need to provide a list of values. You provided: {val}"
                     )
                 iterate_over[key] = cls._values_list_serializer(val)
@@ -113,7 +113,10 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         parsed_list = []
         # Let's iterate over all values so that we can parse them all
         for obj in list_to_parse:
-  Line: 146
+
+            # If the object is a python type, convert it to a node
+            if not isinstance(obj, Node):
+                obj = to_aiida_type(obj)
 
             # If it has just been converted to a node, or it was an unstored node
             # store it so that it gets a pk.

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -431,7 +431,12 @@ class InputIterator(BaseIteratorWorkChain):
         if self._reuse_inputs and hasattr(self.ctx, 'last_inputs'):
             inputs = self.ctx.last_inputs
         else:
-            inputs = AttributeDict(self.exposed_inputs(self._process_class))
+            inputs = AttributeDict(
+                self.exposed_inputs(
+                    self._process_class,
+                    namespace=self._expose_inputs_kwargs.get('namespace', None)
+                )
+            )
 
         # For each key and value in this step, modify the inputs.
         # This is done like this so that add_inputs is a simple method that

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -3,8 +3,8 @@ import itertools
 from functools import partial
 
 from aiida.plugins import DataFactory
-from aiida.engine import WorkChain, while_, ToContext, calcfunction
-from aiida.orm import Float, Str, List, KpointsData, Int, Node, Dict
+from aiida.engine import WorkChain, while_, ToContext
+from aiida.orm import Str, List, KpointsData, Int, Node
 from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.orm.utils import load_node
 from aiida.common import AttributeDict
@@ -12,65 +12,84 @@ from aiida.common import AttributeDict
 from ..calculations.tkdict import FDFDict
 from .base import SiestaBaseWorkChain
 
-# def accept_python_types(spec):
-#     '''
-#     Receives a ProcessSpec object and sets the serializer
-#     for the inputs to `aiida.orm.nodes.data.base.to_aiida_type`.
-
-#     In this way, the user will be able to pass python objects, which
-#     will be automatically converted to aiida nodes.
-#     '''
-
-#     def serializer(obj):
-
-#         if isinstance(obj, list):
-#             serialized = List(list=obj)
-#         else:
-#             serialized = to_aiida_type(obj)
-
-#         return serialized
-
-#     spec.input = partial(spec.input, serializer=serializer)
-
-
 class BaseIteratorWorkChain(WorkChain, ABC):
     '''
     General workflow that runs simulations iteratively.
 
-    The workchain itself can not be used.
+    The workchain itself can not be used. To use it, you need to define classes
+    that inherit from it. These classes will have one main job:
 
-    To use it, you need to define classes that inherit from it.
-    These classes will have two main jobs:
+    Defining a `run_process` method that runs the process given the current
+    value of the iterator. Note that this method does not need to take care of anything
+    else! Following, we display the expanded outline of the workchain in pseudocode
+    to help you understand how it works and realise what do you want to overwrite:
 
-        - Specify the calculation that needs to run iteratively.
-    
-    It relies in a method
-    called `add_inputs` to modify the inputs at each iteration.
-    See `ParameterIterator` and `AttributeIterator` for an example
-    of this.
+    -------------------------------------------------------------------------------
+    cls.initialize:
+        cls._get_iterable:
+            keys = [self._parse_key(key) for key in keys]
+
+    while (cls.next_step): # cls.should_proceed and cls.store_next_val are called inside cls.next_step!
+        - cls.run_batch:
+            for i in range(batch_size):
+                if i!= 0:
+                    cls.store_next_val
+                cls.run_process # You have the current value under self.current_val and
+                                # the keys under self.iteration_keys
+                
+        - cls.analyze_batch:
+            for process in batch:
+                cls.analyze_process(process)
+    cls.return_results
+    --------------------------------------------------------------------------------
+
+    You have probably noted that you can analyze a process without worrying about the batch
+    size by overwriting the `analyze_process` method.
+
+    The main idea is that you probably don't need to subclass this class, because there is
+    probably a subclass defined to serve a general purpose that your workflow fits into.
+    See `InputIterator`, for example. The `BaseIteratorWorkchain` goal is just to provide
+    a basis to handle the iterable and the batch size in a consistent way and facilitate
+    further development.
+
+    Finally, the class might seem unnecessarily complex due to the big number of methods
+    defined in it. In reality, it is quite simple. The splitting of each step in separate
+    methods is intentional to help the developer/user overwrite smalls bits of it without
+    having to reimplement the whole step. Therefore: yes, you are invited to overwrite each
+    little functionality to make it useful for your case :)
+
+    You can even overwrite the input serializers. See `_iterate_input_serializer` and
+    `_values_list_serializer`
     '''
 
-    # Here are some class variables that need to be defined
-    @property
-    @abstractmethod
-    def _process_class(self):
-        pass
-
-    _exclude_process_inputs = ()
-
     @classmethod
-    def _iterate_input_serializer(cls, iterate_input):
+    def _iterate_input_serializer(cls, iterate_over):
         """
-        Parses the input of an the iterator workchain.
+        Parses the "iterate_over" key of the workchain.
+
+        For each key-value of the dictionary, it parses the value (which is a list),
+        using `cls._values_list_serializer`. See its documentation.
+
+        Parameters
+        -----------
+        iterate_over: dict or aiida Dict
+            A dictionary where each key is the name of a parameter we want to iterate
+            over (str) and each value is a list with all the values to iterate over for
+            that parameter.
+
+        Returns
+        -----------
+        aiida Dict
+            the parsed input.
         """
 
-        if isinstance(iterate_input, dict):
-            for key, val in iterate_input.items():
-                iterate_input[key] = cls._values_list_serializer(val)
+        if isinstance(iterate_over, dict):
+            for key, val in iterate_over.items():
+                iterate_over[key] = cls._values_list_serializer(val)
             
-            iterate_input = DataFactory('dict')(dict=iterate_input)
+            iterate_over = DataFactory('dict')(dict=iterate_over)
 
-        return iterate_input
+        return iterate_over
 
     @staticmethod
     def _values_list_serializer(list_to_parse):
@@ -80,17 +99,24 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         This is done because aiida's List does not accept items with certain data structures
         (e.g. StructureData). In this way, we normalize the input to a list of pk, so that at
         each iteration we can access the value of the node.
+
+        Note that if you modify/overwrite this method you should be take a look to the `next_val` method.
         '''
 
         parsed_list = []
+        # Let's iterate over all values so that we can parse them all
         for obj in list_to_parse:
 
+            # If it was a python type, convert it to aiida type (e.g. a node)
             if not isinstance(obj, Node):
                 obj = to_aiida_type(obj)
 
+            # If it has just been converted to a node, or it was an unstored node
+            # store it so that it gets a pk.
             if not obj.is_stored:
                 obj.store()
 
+            # Now that we are sure the node has a pk, we append it to the list
             parsed_list.append(obj.pk)
         
         return List(list=parsed_list)
@@ -100,54 +126,73 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         super().define(spec)
 
         # Define the outline of the workflow, i.e. the order in which methods
-        # should be executed
+        # should be executed. See this class' documentation for an extended
+        # version of it
         spec.outline(cls.initialize,
                      while_(cls.next_step)(
                          cls.run_batch,
                          cls.analyze_batch,
                      ), cls.return_results)
 
-        # Define all the inputs that this workchain expects
-
-        # With this, we will automatically accept python datatypes, saving the user
-        # the hassle of passing aiida types
-        # accept_python_types(spec)
-
-        # Inputs related to the variable parameter
+        # Add inputs that are general to all iterator workchains. This is the stuff
+        # that the BaseIteratorWorkchain manages for you: the iterable and batching.
+        # More inputs can be defined in subclasses.
         spec.input(
             "iterate_over",
             valid_type=DataFactory('dict'),
-            serializer=cls._iterate_input_serializer, # The values list will always be a list of node pks.
+            serializer=cls._iterate_input_serializer,
             required=False,
-            help='''A dictionary that indicates what to iterate over'''
+            help='''A dictionary where each key is the name of a parameter we want to iterate
+            over (str) and each value is a list with all the values to iterate over for
+            that parameter. Each value in the list can be either a node (unstored or stored)
+            or a simple python object (str, float, int, bool).
+            
+            Note that each subclass might parse this keys and values differently, so you should
+            know how they do it.
+            '''
         )
         spec.input(
             "iterate_mode", valid_type=Str, default=lambda: Str('zip'),
-            help="Indicates the way the parameters should be iterated."
+            help='''Indicates the way the parameters should be iterated.
+            Currently allowed values are:
+                - 'zip': zips all the parameters together (all parameters should
+                have the same number of values!)
+                - 'product': performs a cartesian product of the parameters. That is,
+                all possible combinations of parameters and values are explored.
+             '''
         )
         spec.input(
             "batch_size", valid_type=Int, default=lambda: Int(1),
-            help="The number of simulations that should run at the same time"
+            help='''The maximum number of simulations that should run at the same time. 
+            You can set this to a very large number to make sure that all simulations run in
+            one single batch if you want.'''
         )
 
-        # We expose the inputs of the workchain that is run at each iteration
-        spec.expose_inputs(cls._process_class, exclude=cls._exclude_process_inputs, )
-        spec.inputs._ports['pseudos'].dynamic = True
-
     def initialize(self):
+        """
+        Initializes the variables that are used through the workchain.
+        """
 
         self.ctx.variable_values = []
         self.ctx.values_iterable = self._get_iterable()
 
     def _get_iterable(self):
+        """
+        Builds the iterable that will generate values.
+        """
 
         iterate_over = self.inputs.iterate_over.get_dict()
         iterate_mode = self.inputs.iterate_mode.value
 
+        # Get the names of the parameters
         self.ctx.iteration_keys = tuple(iterate_over.keys())
+        # Then the values
         self.ctx.iteration_vals = tuple(iterate_over[key] for key in self.ctx.iteration_keys)
+        # And now that we've retrieved the values, parse the keys if necessary.
+        # Note that by default _parse_key just returns the same key.
         self.ctx.iteration_keys = tuple(self._parse_key(key) for key in self.ctx.iteration_keys)
 
+        # Define the iterable depending on the iterate_mode.
         if iterate_mode == 'zip':
             iterable = zip(*self.ctx.iteration_vals)
         elif iterate_mode == 'product':
@@ -156,6 +201,11 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         return iterable
 
     def _parse_key(self, key):
+        """
+        This method is an opportunity for the user to modify the iteration keys.
+
+        It is called in `_get_iterable`
+        """
         return key
 
     def next_step(self):
@@ -170,13 +220,12 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         '''
 
         # Give the oportunity to abort next cycle
-        if not self.should_proceed:
+        if not self.should_proceed():
             return False
 
         # Otherwise, try to get a new value
         try:
             self.store_next_val()
-
         except StopIteration:
             # However, it's possible that there are no more values to try
             return False
@@ -184,28 +233,43 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         return True
 
     # The only logic BaseIteratorWorkChain knows is to run until there are no more
-    # values to iterate or we've reached the number of steps
+    # values to iterate.
     # This method may be overwritten by child classes (see ConvergenceWorkChain)
-    should_proceed = True
+    def should_proceed(self):
+        return True
 
     def next_val(self):
         '''
         Gets the next value to try.
 
+        This method is called by `store_next_val`.
+
         NOTE: Calling this method irreversibly 'outdates' the current value. Therefore
         it makes no sense to call it outside the `next_step` method.
+
+        Since the input values are normalized to aiida pks, we load the corresponding
+        nodes here. This method won't hold if the serializer is modified, so it should be
+        changed accordingly.
         '''
 
+        # Get the next values
         next_pks = next(self.ctx.values_iterable)
         
+        # For each value, load the corresponding node
         return tuple(load_node(next_pk) for next_pk in next_pks)
     
     def store_next_val(self):
+        """
+        Gets the next value from the iterator and appends it to the list of values.
 
+        It also informs of what are the values that have been stored for use.
+        """
+
+        # Store the next value
         self.ctx.variable_values.append(self.next_val())
 
+        # Inform about it
         info = '\n\t'.join([f'"{key}": {val}' for key, val in zip(self.ctx.iteration_keys, self.current_val)])
-
         self.report(f'Next values:{"{"}\n\t{info}\n{"}"}')
     
     @property
@@ -214,7 +278,9 @@ class BaseIteratorWorkChain(WorkChain, ABC):
 
     def run_batch(self):
         '''
-        Runs the calculation with the current value of the variable parameter.
+        Takes care of handling a batch of simulations.
+
+        For each item in the batch, it calls `run_process`.
         '''
 
         self.ctx.last_step_processes = []
@@ -233,43 +299,34 @@ class BaseIteratorWorkChain(WorkChain, ABC):
                     # we will just run a smaller batch
                     break
 
-            # Run the process and store the results
+            # Submit the process
             process_node = self.run_process()
 
+            # Store the id of the process so that we can retrieve it later from context
             self.ctx.last_step_processes.append(process_node.uuid)
+
+            # And then store the process (this will be passed to context at the end of the method)
             processes[process_node.uuid] = process_node
 
         self.report(f'Launched batch of {len(self.ctx.last_step_processes)}/{batch_size} processes')
 
+        # Wait for the processes to finish
         return ToContext(**processes)
 
-    def run_process(self):
-
-        # Get the general inputs for the siesta run
-        inputs = AttributeDict(self.exposed_inputs(self._process_class))
-
-        for key, val in zip(self.ctx.iteration_keys, self.current_val):
-            self.add_inputs(key, val, inputs)
-
-        # Run the process and store the results
-        process_node = self.submit(self._process_class, **inputs)
-
-        return process_node
-
     @abstractmethod
-    def add_inputs(self, key, val, inputs):
-        '''
-        This method should be implemented in child classes.
-
-        It takes all the inputs of the SIESTA calculation and it is expected to modify them
-        in place according to the current iteration. See `ParameterIterator` and `AttributeIterator`
-        for examples of this.
-        '''
+    def run_process(self):
+        """
+        This method should be overwritten to implement running the process.
+        """
 
     def analyze_batch(self):
         '''
-        Here, one could process the results of the simulation
-        (which has been put into context)
+        Here, one could process the results of the processes that have been ran
+        in the last batch.
+
+        This default implementation just grabs each process in the order they have been
+        launched and passes it to `analyze_process`. In this way, `analyze_process` does not need
+        to handle anything related to the batch.
         '''
 
         for process_id in self.ctx.last_step_processes:
@@ -279,149 +336,388 @@ class BaseIteratorWorkChain(WorkChain, ABC):
     def analyze_process(self, process_node):
         """
         A child class has the oportunity to analyze a process here.
+
+        Parameters
+        -----------
+        process_node:
+            a process that has been ran in the batch.
         """
 
     def return_results(self):
         '''
-        Takes care of returning the results of the workchain to the user.
+        Takes care of postprocessing and returning the results of the workchain to the user.
+        (if any outputs need to be returned)
         '''
 
 
-class AttributeIterator(BaseIteratorWorkChain):
+class InputIterator(BaseIteratorWorkChain):
+    """
+    General workchain to iterate over a same process with different inputs.
 
-    def _parse_val(self, key, val, inputs):
-        return val
+    This class can not be used. However, you don't need to much!
 
-    def _attr_from_key(self, key):
-        return key
+    All you need to provide in a subclass to make use of this iterator is 
+    the process to run. The way you do this is by setting the `_process_class`
+    variable. See examples. Once you have defined the process to run, this workchain
+    exposes its inputs and runs the process iteritatively.
 
-    def add_inputs(self, key, val, inputs):
-        '''
-        Adds the attribute with the appropiate value to the inputs that go
-        to the SIESTA calculation.
-        '''
+    The outline of this workchain is exactly the same as `BaseIteratorWorkchain`
+    (see its docs). The only difference is that this class implements a `run_process`
+    method that, in pseudocode, looks like this:
 
-        attribute = self._attr_from_key(key)
-        parsed_val = self._parse_val(key, val, inputs)
+    cls.run_process:
 
-        setattr(inputs, attribute, parsed_val)
+        # Get the exposed inputs of the process to run
+        inputs = get_exposed_inputs(MyProcess)
 
+        # Modify the inputs
+        for key, val in zip(iteration_keys, vals):
+            cls.add_inputs(key, val, inputs):
+                attribute = cls._attr_from_key(key)
+                val = self._parse_val(key, val, inputs)
+                setattr(inputs, attribute, parsed_val)
 
-class SiestaIterator(AttributeIterator):
+        # Submit the process with the modified inputs
+        submit(MyProcess, **inputs)
+    
+    Therefore, if you want to add extra functionality to it, you probably should be
+    good by overwriting the `_attr_from_key` or `_parse_val` methods, which by default
+    do nothing. See `SiestaIterator` for an example of this.
 
-    _process_class = SiestaBaseWorkChain
-    _exclude_inputs = ('metadata',)
-    _attribute = None
+    Examples
+    ----------
+    class MyIterator(InputIterator):
+        _process_class = MyProcess
+
+        # This class variable is passed directly to spec.expose_inputs
+        _expose_inputs_kwargs = {'exclude': ('input_that_i_dont_want_to_expose', )}
+
+    `MyIterator` will now run MyProcess iterating over all the input values.
+    """
+
+    # THE PROCESS CLASS NEEDS TO BE PROVIDED IN CHILD CLASSES!
+    _process_class = None
+    # This class variable is passed directly to spec.expose_inputs
+    _expose_inputs_kwargs = {}
 
     @classmethod
     def define(cls, spec):
         super().define(spec)
 
-        spec.input('units', valid_type=Str, required=False, help='The units of the parameter')
+        # We expose the inputs of the workchain that is run at each iteration
+        spec.expose_inputs(cls._process_class, **cls.expose_inputs_kwargs)
+
+    def run_process(self):
+        '''
+        Given a current value (self.current_val), runs the process.
+
+        Before running, it sets up the inputs.
+        '''
+
+        # Get the exposed inputs for the process that we want to run.
+        inputs = AttributeDict(self.exposed_inputs(self._process_class))
+
+        # For each key and value in this step, modify the inputs.
+        # This is done like this so that add_inputs is a simple method that
+        # just takes a key and modifies the inputs accordingly. This should
+        # be fine as most certainly each parameter can be set independently.
+        for key, val in zip(self.ctx.iteration_keys, self.current_val):
+            self.add_inputs(key, val, inputs)
+
+        # Run the process and store the results
+        process_node = self.submit(self._process_class, **inputs)
+
+        return process_node
+
+    def add_inputs(self, key, val, inputs):
+        '''
+        Given a parameter and the value, modify the inputs.
+
+        We need to:
+            - Get the input key (with `_attr_from_key`)
+            - Get the parsed value (with `_parse_val`)
+
+        Parameters
+        -----------
+        key: str
+            the parameter that we need to set
+        val: any
+            the value for this parameter and this step.
+        inputs: AttributeDict
+            all the already existing inputs.
+        '''
+
+        # Get the input key
+        attribute = self._attr_from_key(key)
+
+        # Get the parsed value
+        parsed_val = self._parse_val(val, key, inputs)
+
+        # Update the inputs AttributeDict
+        setattr(inputs, attribute, parsed_val)
+
+    def _parse_val(self, val, key, inputs):
+        '''
+        An opportunity to parse the value before setting it as an input.
+
+        E.g.:
+            if the parameter 'kpoints_whatever' means that you need to parse
+            the value into a KpointsData() and set it to the 'kpoints' input,
+            this should return the generated KpointsData() and use `_attr_from_key`
+            accordingly.
+
+        May be overwritten by child classes.
+
+        Parameters
+        -----------
+        val: any
+            the value to parse
+        key: str
+            the parameter to which this value belongs
+        inputs: AttributeDict
+            all the already existing inputs.
+        '''
+        return val
+
+    def _attr_from_key(self, key):
+        """
+        Returns the input key to which the value that corresponds to the parameter
+        should be set.
+
+        E.g.:
+            if the parameter 'kpoints_whatever' means that you need to parse
+            the value into a KpointsData() and set it to the 'kpoints' input,
+            this should return 'kpoints' 
+
+        May be overwritten by child classes.
+
+        Parameters
+        ------------
+        key: str
+            the name of the parameter.
+        """
+        return key
+
+
+class SiestaIterator(InputIterator):
+    """
+    General iterator for ANY parameter in SIESTA.
+
+    It runs `SiestaBaseWorkChain` iteratively setting the inputs 
+    appropiately at each iteration.
+
+    With the help of the global dictionaries `_BASIS_PARAMS`, 
+    `_PARAMS` and `_INPUT_ATTRIBUTES`, it decides what each parameter
+    key in the "iterate_over" needs to do (i.e. which input to modify and
+    how to parse the value into a valid input).
+    """
+
+    _process_class = SiestaBaseWorkChain
+    _expose_inputs_kwargs = {'exclude': ('metadata',)}
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+
+        spec.inputs._ports['pseudos'].dynamic = True
+        # spec.input('units', valid_type=Str, required=False, help='The units of the parameter')
 
     def initialize(self):
-        self.ctx._attributes = {}
+        """
+        Initialize the dicts to store input keys and parsing functions for
+        each parameter.
+        """
+        self.ctx._input_keys = {}
         self.ctx._parsing_funcs = {}
 
         super().initialize()
 
     def _parse_key(self, key):
-        
-        attribute, parsing_func = self.attribute_and_parsing_func(key)
+        """
+        Uses the _parse_key method to store the input keys and parsing functions
+        that we are going to use through the workchain.
 
-        self.ctx._attributes[key] = attribute
+        Parameters
+        -----------
+        key: str
+            the name of the parameter, as passed in the "iterate_over" input.
+        """
+        
+        input_key, parsing_func = self.input_key_and_parsing_func(key)
+
+        self.ctx._input_keys[key] = input_key
         self.ctx._parsing_funcs[key] = parsing_func
 
         return key
     
     def _attr_from_key(self, key):
-        return self.ctx._attributes[key]
+        '''
+        Returns the input key to which the parameter belongs.
 
-    def _parse_val(self, key, val, inputs):
+        Parameters
+        ------------
+        key: str
+            the name of the parameter.
+        '''
+        return self.ctx._input_keys[key]
 
+    def _parse_val(self, val, key, inputs):
+        '''
+        Parses the value using the parsing function that we have stored for this parameter.
+
+        Parameters
+        -----------
+        val: any
+            the value to parse
+        key: str
+            the parameter to which this value belongs
+        inputs: AttributeDict
+            all the already existing inputs.
+        '''
         return self.ctx._parsing_funcs[key](val, inputs)
 
     @staticmethod
-    def attribute_and_parsing_func(parameter):
+    def input_key_and_parsing_func(parameter):
         '''
-        Chooses which attribute to use for that convergence parameter
+        Chooses which input key and parsing function to use for a parameter key.
+
+        Parameters
+        ----------
+        parameter: str
+            a key passed to the "iterate_over" input of the workchain.
         '''
 
+        # Find out to which of the three global dictionaries does the
+        # parameter belong.
         if parameter in _INPUT_ATTRIBUTES['params']:
-            attribute = parameter
+            input_key = parameter
             params_dict = _INPUT_ATTRIBUTES
         elif parameter.startswith('pao'):
-            attribute = 'basis'
+            input_key = 'basis'
             params_dict = _BASIS_PARAMS
             parameter = FDFDict.translate_key(parameter)
         else:
-            attribute = 'parameters'
+            input_key = 'parameters'
             params_dict = _PARAMS
             parameter = FDFDict.translate_key(parameter)
 
-        # Let's choose the parsing function
-        if parameter in params_dict['params']:
-            param_info = params_dict["params"].get(parameter, None)
+        # Once we have the corresponding dict, we check if the parameter is defined.
+        # If it is there, we get the dictionary that defines how it should be used
+        param_info = params_dict["params"][parameter].get(parameter, None)
 
-            units = None
-            try:
-                units = param_info['defaults']['units']
-            except:
-                pass
+        # Try to get its default units
+        units = None
+        try:
+            units = param_info['defaults']['units']
+        except (KeyError, AttributeError):
+            pass
 
-            
-            default_parse_func = params_dict.get('default_parse_func', None)
-            if default_parse_func is not None:
-                default_parse_func = partial(default_parse_func, parameter=parameter, units=units)
+        # Get the default parsing function for the global dictionary
+        # that the parameter belongs to, because if we don't find a
+        # particular one for the parameter we are going to use this one
+        default_parse_func = params_dict.get('default_parse_func', None)
+        if default_parse_func is not None:
+            default_parse_func = partial(default_parse_func, parameter=parameter, units=units)
 
-            if param_info is None:
-                parsing_func = default_parse_func
-            else:
-                attribute = param_info.get('attribute', attribute)
-                parsing_func = param_info.get('parse_func', default_parse_func)
+        # Now try to get the parsing function and if we can't, use the default one
+        if param_info is None:
+            parsing_func = default_parse_func
+        else:
+            input_key = param_info.get('input_key', input_key)
+            parsing_func = param_info.get('parse_func', default_parse_func)
 
-        return attribute, parsing_func
+        return input_key, parsing_func
 
-def set_up_parameters_dict(val, inputs, parameter, attribute, units=None):
+def set_up_parameters_dict(val, inputs, parameter, input_key, units=None):
+    """
+    Parsing function that sets an fdf parameter.
+
+    This is used by the basis parameters (input_key='basis') and the rest of
+    fdf parameters (input_key='parameters')
+
+    Parameters
+    -----------
+    val: str, float, int, bool
+        the value to set for the parameter.
+    inputs: AttributeDict
+        all the current inputs, so that we can extract the curren FDFdict.
+    parameter: str
+        the name of the fdf flag. Case and hyphen insensitive. 
+    input_key: str
+        the input of the fdf dict that should be modified.
+    units: str
+        the units to use if the value is a number.
+    """
 
     val = val.value
 
-    # Convert the inputs to an fdf dict to avoid duplicate keys
-    parameters = getattr(inputs, attribute, DataFactory('dict')())
+    # Get the current FDFdict for the corresponding input
+    parameters = getattr(inputs, input_key, DataFactory('dict')())
     parameters = FDFDict(parameters.get_dict())
 
-    if units is not None:
+    # Set the units for the value if needed
+    if units is not None and isinstance(val, (int, float)):
         val = f'{val} {getattr(units, "value", units)}'
 
+    # Then set the value of the parameter in the FDF dict.
     parameters[parameter] = val
 
-    # And then just translate it again to a dict to use it for parameters
+    # And then just translate it again to a dict to use it in the input
     return DataFactory('dict')(dict={key: val for key, (val, _) in parameters._storage.items()})
 
-def set_up_kpoint_grid(val, inputs, attribute='kpoints', mode='distance'):
+def set_up_kpoint_grid(val, inputs, input_key='kpoints', mode='distance'):
+    """
+    Parsing function that sets a kpoint grid.
 
-    old_kpoints = getattr(inputs, attribute, None)
+    This is used by the basis parameters (input_key='basis') and the rest of
+    fdf parameters (input_key='parameters')
 
+    Parameters
+    -----------
+    val: str, float, int, bool
+        the value to set for the parameter.
+    inputs: AttributeDict
+        all the current inputs, so that we can extract the curren FDFdict.
+    input_key: str
+        the input of the fdf dict that should be modified.
+    mode: {'distance', '0_component', '1_component', '2_component'}
+        specifies how to interpret the value.
+
+        If 'distance': the value is interpreted as the maximum distance
+        between two grid points along a reciprocal axis.
+
+        Else, it is interpreted as the number of points for one of the components
+        of the grid.
+    units: str
+        the units to use if the value is a number.
+    """
+
+    # If there is already a KpointsData() in inputs grab it to modify it
+    old_kpoints = getattr(inputs, input_key, None)
+
+    # Else define a new one
     if old_kpoints is None:
         old_kpoints = KpointsData()
 
+    # Get the mesh and the offset
     try:
         mesh, offset = old_kpoints.get_kpoints_mesh()
     except (KeyError, AttributeError):
         mesh, offset = [1, 1, 1], [0, 0, 0]
 
+    # Get also the cell
     if not hasattr(old_kpoints, 'cell'):
         old_kpoints.set_cell_from_structure(inputs.structure)
 
-    
     cell = old_kpoints.cell
 
+    # And finally define the new KpointsData according to the required mode.
     if mode == 'distance':
         new_kpoints = KpointsData()
         new_kpoints.set_cell(cell)
         new_kpoints.pbc = old_kpoints.pbc
         new_kpoints.set_kpoints_mesh_from_density(val.value, offset=offset)
-
+    
     elif mode.endswith('component'):
 
         component = [ax for ax in range(3) if mode.startswith(str(ax))][0]
@@ -434,12 +730,12 @@ def set_up_kpoint_grid(val, inputs, attribute='kpoints', mode='distance'):
     return new_kpoints
 
 
-# Instead of defining classes for each param/attribute, another approach
-# could be to have dicts defining "defaults" for each parameter attribute.
-# For more complicated cases like kpoints we do need to define a new class though.
+# Following, we have the global dictionaries that help us choose what each parameter
+# means in the SiestaIterator
 
+# Parameters for the basis fdf dict
 _BASIS_PARAMS = {
-    'default_parse_func': partial(set_up_parameters_dict, attribute='basis'),
+    'default_parse_func': partial(set_up_parameters_dict, input_key='basis'),
     'params': FDFDict(
         paobasissize={'defaults': {
             'values_list': ['SZ', 'SZP', 'DZ', 'DZP', 'TZ', 'TZP']
@@ -450,14 +746,15 @@ _BASIS_PARAMS = {
     )
 }
 
+# Rest of fdf dict
 _PARAMS = {
-    'default_parse_func': partial(set_up_parameters_dict, attribute='parameters'),
+    'default_parse_func': partial(set_up_parameters_dict, input_key='parameters'),
     'params': FDFDict(
         meshcutoff={'defaults': {'units': 'Ry', 'init_value': 100, 'step': 100}}
     )
 }
 
-# These are all the valid attributes for inputs (I believe)
+# Parameters that are directly set as input keys.
 _INPUT_ATTRIBUTES = {
     'default_parse_func': None,
     'params': {
@@ -470,12 +767,12 @@ _INPUT_ATTRIBUTES = {
         'parent_calc_folder': {},
         'kpoints': {},
         'kpoints_density':{
-            'attribute': 'kpoints',
+            'input_key': 'kpoints',
             'parse_func': set_up_kpoint_grid
         },
         **{
             f'kpoints_{ax}': {
-                'attribute': 'kpoints',
+                'input_key': 'kpoints',
                 'parse_func': partial(set_up_kpoint_grid, mode=f'{ax}component')
             } for ax in range(3)
         }

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -609,7 +609,7 @@ class SiestaIterator(InputIterator):
         units = None
         try:
             units = param_info['defaults']['units']
-        except (KeyError, AttributeError):
+        except (KeyError, AttributeError, TypeError):
             pass
 
         # Get the default parsing function for the global dictionary

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -1,0 +1,417 @@
+import itertools
+from functools import partial
+import numpy as np
+
+from aiida.plugins import DataFactory
+from aiida.engine import WorkChain, calcfunction, while_, ToContext
+from aiida.orm import Float, Str, List, KpointsData, Bool, Int
+from aiida.orm.nodes.data.base import to_aiida_type
+from aiida.common import AttributeDict
+
+from ..calculations.tkdict import FDFDict
+from .base import SiestaBaseWorkChain
+
+def accept_python_types(spec):
+    '''
+    Receives a ProcessSpec object and sets the serializer 
+    for the inputs to `aiida.orm.nodes.data.base.to_aiida_type`.
+
+    In this way, the user will be able to pass python objects, which
+    will be automatically converted to aiida nodes.
+    '''
+
+    def serializer(obj):
+
+        if isinstance(obj, list):
+            return List(list=obj)
+        else:
+            return to_aiida_type(obj)
+
+    spec.input = partial(spec.input, serializer=serializer)
+
+class BaseIteratorWorkChain(WorkChain):
+    '''
+    General workflow that runs SIESTA simulations iteratively.
+
+    The workflow itself can not be used. It relies in a method
+    called `add_inputs` to modify the inputs at each iteration.
+    See `ParameterIterator` and `AttributeIterator` for an example
+    of this.
+    '''
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+
+        # Define the outline of the workflow, i.e. the order in which methods
+        # should be executed
+        spec.outline(
+            cls.initialize,
+            while_(cls.next_step)(
+                cls.run_calc,
+                cls.process_calc,
+            ),
+            cls.return_results
+        )
+
+        # Define all the inputs that this workchain expects
+
+        # With this, we will automatically accept python datatypes, saving the user
+        # the hassle of passing aiida types
+        accept_python_types(spec)
+
+        # Inputs related to the variable parameter
+        spec.input(
+            "init_value",
+            valid_type=(Int, Float),
+            required=False,
+            help="The inital value of the parameter."
+        )
+        spec.input(
+            "step",
+            valid_type=(Int, Float),
+            required=False,
+            help="The step to apply for each iteration."
+        )
+        spec.input(
+            'steps',
+            valid_type=Int,
+            required=False,
+            help="The maximum number of steps to take"
+        )
+        spec.input(
+            "values_list",
+            valid_type=List,
+            required=False,
+            help='''The list of values to try. Use this if `init_value` and `step` are not
+            suitable for you. E.g. the values are strings or the steps are not regular.'''
+        )
+
+        # Inputs related to the parameter to converge
+        spec.input(
+            "target",
+            valid_type=Str,
+            required=False,
+            default=lambda: Str('E_KS'),
+            help="The parameter that you want to track."
+        )
+        spec.expose_inputs(SiestaBaseWorkChain, exclude=('metadata',))
+        spec.inputs._ports['pseudos'].dynamic = True
+        
+        # Define what are the outputs that this workchain will return
+        spec.output('attempted_values')
+
+    def initialize(self):
+
+        self.ctx.variable_values = []
+        self.ctx.target_values = []
+
+        self.ctx.values_iterable = self._get_iterable()
+
+    def _get_iterable(self):
+
+        # The values to try will be provided by an iterator
+        if 'values_list' in self.inputs:
+            iterable = iter(self.inputs.values_list.get_list())
+        elif hasattr(self, '_default_values_list') and 'init_value' not in self.inputs:
+            iterable = iter(self._default_values_list)
+        else:
+            init_val = self.inputs.init_value.value if 'init_value' in self.inputs else self._default_init
+            step = self.inputs.step.value if 'step' in self.inputs else self._default_step
+
+            iterable = itertools.count(init_val, step) 
+
+        return iterable    
+
+    def next_step(self):
+        '''
+        Puts the next step in context.
+
+        Returns
+        ---------
+        boolean
+            Whether it should move to the next step or not (see this workchain's
+            outline in the `define` method)
+        '''
+
+        # Give the oportunity to abort next cycle
+        if not self.should_proceed:
+            return False
+
+        # Check if we already did the number of steps requested
+        # Remember that we've not yet appended the next value, that's
+        # why we check >= steps and not > steps.
+        if 'steps' in self.inputs and len(self.ctx.variable_values) >= self.inputs.steps.value:
+            return False
+
+        # Otherwise, try to get a new value
+        try:
+            self.ctx.variable_values.append(self._next_val())
+
+            self.report(f'Next value: {self.ctx.variable_values[-1]}')
+        except StopIteration:
+            # However, it's possible that there are no more values to try
+            return False
+        
+        return True
+
+    # The only logic BaseIteratorWorkChain knows is to run until there are no more
+    # values to iterate or we've reached the number of steps
+    # This method may be overwritten by child classes (see ConvergenceWorkChain)
+    should_proceed = True
+
+    def _next_val(self):
+        '''
+        Gets the next value to try.
+
+        NOTE: Calling this method irreversibly 'outdates' the current value. Therefore
+        it makes no sense to call it outside the `next_step` method.
+        '''
+        return next(self.ctx.values_iterable)
+
+    @property
+    def current_val(self):
+        return self.ctx.variable_values[-1]
+
+    def run_calc(self):
+        '''
+        Runs the calculation with the current value of the variable parameter.
+        '''
+
+        # Get the general inputs for the siesta run
+        inputs = AttributeDict(self.exposed_inputs(SiestaBaseWorkChain))
+        # Let the
+        self.add_inputs(inputs)
+        
+        # Run the SIESTA simulation and store the results
+        calculation = self.submit(SiestaBaseWorkChain, **inputs)
+
+        return ToContext(calculation=calculation)
+
+    def process_calc(self):
+        pass
+
+    def return_results(self):
+        '''
+        Takes care of returning the results of the workchain to the user.
+        '''
+        pass
+
+class ParameterIterator(BaseIteratorWorkChain):
+
+    _units = None
+
+    @classmethod
+    def define(self, spec):
+        super().define(spec)
+
+        # If the user is using directly this class, give the option to choose
+        # the parameter they want to converge
+        if not hasattr(self, '_parameter'):
+            spec.input(
+                'parameter',
+                valid_type=Str,
+                required=True,
+                help='The parameter that you want to vary to find convergence'
+            )
+
+            spec.input('units', valid_type=Str, required=False, help='The units of the parameter')
+    
+    def initialize(self):
+        super().initialize()
+
+        if hasattr(self, '_parameter'):
+            self.ctx.parameter = self._parameter
+        else:
+            self.ctx.parameter = self.inputs.parameter.value
+
+    def add_inputs(self, inputs):
+        '''
+        Adds the parameter with the appropiate value to the inputs that go
+        to the SIESTA calculation.
+        '''
+
+        # Maybe we want to update some parameters from a dict different
+        # than inputs.parameters(i.e. the basis dict)
+        attr = getattr(self, '_parameters_attribute', 'parameters')
+
+        # Convert the inputs to an fdf dict to avoid duplicate keys
+        parameters = getattr(inputs, attr, DataFactory('dict')())
+        parameters = FDFDict(parameters.get_dict())
+
+        val = self.current_val 
+
+        units = getattr(self.inputs, 'units', self._units)
+        if units is not None:
+            val = f'{val} {getattr(units, "value", units)}'
+
+        parameters[self.ctx.parameter] = val
+
+        # And then just translate it again to a dict to use it for parameters
+        new_parameters = DataFactory('dict')(dict={key: val for key, (val, _) in parameters._storage.items()})
+        setattr(inputs, attr, new_parameters)
+
+class BasisParameterIterator(ParameterIterator):
+    _parameters_attribute = 'basis'
+
+class AttributeIterator(BaseIteratorWorkChain):
+
+    @classmethod
+    def define(self, spec):
+        super().define(spec)
+
+        # If the user is using directly this class, give the option to choose
+        # the parameter they want to converge
+        if not hasattr(self, '_attribute'):
+            # We are going to add here inputs specific to converging a parameter 
+            spec.input(
+                'attribute',
+                valid_type=Str,
+                required=True,
+                help='The attribute that you want to vary to find convergence'
+            )
+
+    def initialize(self):
+        super().initialize()
+
+        if hasattr(self, '_attribute'):
+            self.ctx.attribute = self._attribute
+        else:
+            self.ctx.attribute = self.inputs.attribute.value
+
+    def add_inputs(self, inputs):
+        '''
+        Adds the attribute with the appropiate value to the inputs that go
+        to the SIESTA calculation.
+        '''
+
+        setattr(inputs, self.ctx.attribute, self.current_val)
+
+class BasisSizeIterator(BasisParameterIterator):
+
+    _parameter = 'pao-basissize'
+    _default_values_list = ['SZ', 'SZP', 'DZ', 'DZP', 'TZ', 'TZP']
+
+class MeshCutoffIterator(ParameterIterator):
+
+    _parameter = 'meshcutoff'
+    _units = 'Ry'
+    _default_init = 100
+    _default_step = 100
+
+class KpointComponentIterator(AttributeIterator):
+
+    _attribute = 'kpoints'
+
+    @classmethod
+    def define(cls, spec):
+        super().define(spec)
+
+        # Inputs related to the variable parameter
+        spec.input(
+            "component",
+            valid_type=Int,
+            required=False,
+            help="The k component to converge. One of {0,1,2}"
+        )
+    
+    @property
+    def current_val(self):
+
+        k_val = super().current_val
+
+        # If there is already some kpoints, then we are going to use them
+        if 'kpoints' in self.inputs:
+            mesh, offset = self.inputs.kpoints.get_kpoints_mesh()
+        else:
+            # Otherwise we will just create it
+            mesh = [1,1,1]
+            offset = [0,0,0]
+
+        mesh[self.inputs.component.value] = int(k_val)
+
+        k_mesh = KpointsData()
+        k_mesh.set_kpoints_mesh(mesh, offset)
+
+        return k_mesh
+
+class EnergyShiftIterator(BasisParameterIterator):
+
+    _parameter = 'pao-energyshift'
+    _units = 'Ry'
+
+
+basis_params = FDFDict(
+    paobasissize={
+        'defaults': {
+            'values_list': ['SZ', 'SZP', 'DZ', 'DZP', 'TZ', 'TZP']
+        }
+    },
+    paoenergyshift={
+        'defaults': {
+            'units': 'Ry'
+        }
+    }
+)
+
+params = FDFDict(
+    meshcutoff={
+        'defaults': {
+            'units': 'Ry',
+            'init_value': 100,
+            'step': 100
+        }
+    }
+)
+
+attributes = {}
+
+preset_iters = {
+    ParameterIterator: params,
+    BasisParameterIterator: basis_params,
+    AttributeIterator: attributes
+}
+
+def get_iterator_and_defaults(iterate_over):
+
+    for IteratorClass, presets in preset_iters.items():
+
+        # This try-except loop is a workaround because FDF dict
+        # does not have regular dict behavior.
+        # https://github.com/albgar/aiida_siesta_plugin/issues/47
+        try:
+            preset = presets[iterate_over]
+            if preset is None:
+                raise KeyError
+
+            defaults = preset.get("defaults", {})
+            break
+
+        except KeyError:
+            continue
+    else:
+        # If we haven't found it a default for it, we will try to
+        # assume it
+        if FDFDict.translate_key(iterate_over)[:3] == 'pao':
+            IteratorClass = BasisParameterIterator
+        else:
+            IteratorClass = ParameterIterator
+
+        defaults = {}
+
+    # Add the setting that will indicate what are we iterating over
+    if IteratorClass in (ParameterIterator, BasisParameterIterator):
+        defaults['parameter'] = iterate_over
+    elif IteratorClass is AttributeIterator:
+        defaults['attribute'] = iterate_over
+        
+    return IteratorClass, defaults
+
+def iterate(over, call_method='run', **kwargs):
+    from aiida.engine import run, submit
+
+    Iterator, defaults = get_iterator_and_defaults(over)
+
+    execute = run if call_method is 'run' else submit
+
+    return execute(Iterator, *args, **{**defaults, **kwargs})

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import itertools
-from functools import partial, reduce
+from functools import partial
+import numpy as np
 
 from aiida.plugins import DataFactory
 from aiida.engine import WorkChain, while_, ToContext
@@ -86,6 +87,8 @@ class BaseIteratorWorkChain(WorkChain, ABC):
 
         if isinstance(iterate_over, dict):
             for key, val in iterate_over.items():
+                if not isinstance(val, (list, tuple, np.ndarray)):
+                    raise ValueError(f"We can not understand how to iterate over '{key}', you need to provide a list of values. You provided: {val}")
                 iterate_over[key] = cls._values_list_serializer(val)
 
             iterate_over = DataFactory('dict')(dict=iterate_over)
@@ -101,7 +104,7 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         (e.g. StructureData). In this way, we normalize the input to a list of pk, so that at
         each iteration we can access the value of the node.
 
-        Note that if you modify/overwrite this method you should be take a look to the `next_val` method.
+        Note that if you modify/overwrite this method you should take a look to the `next_val` method.
         '''
 
         parsed_list = []
@@ -140,7 +143,7 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         # More inputs can be defined in subclasses.
         spec.input(
             "iterate_over",
-            valid_type=(DataFactory('dict'), List),
+            valid_type=DataFactory('dict'),
             serializer=cls._iterate_input_serializer,
             required=False,
             help='''A dictionary where each key is the name of a parameter we want to iterate

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -38,7 +38,7 @@ class BaseIteratorWorkChain(WorkChain, ABC):
                     cls.store_next_val
                 cls.run_process # You have the current value under self.current_val and
                                 # the keys under self.iteration_keys
-                
+
         - cls.analyze_batch:
             for process in batch:
                 cls.analyze_process(process)
@@ -88,7 +88,10 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         if isinstance(iterate_over, dict):
             for key, val in iterate_over.items():
                 if not isinstance(val, (list, tuple, np.ndarray)):
-                    raise ValueError(f"We can not understand how to iterate over '{key}', you need to provide a list of values. You provided: {val}")
+                    raise ValueError(
+                        f"We can not understand how to iterate over '{key}', " 
+                        f"you need to provide a list of values. You provided: {val}"
+                    )
                 iterate_over[key] = cls._values_list_serializer(val)
 
             iterate_over = DataFactory('dict')(dict=iterate_over)
@@ -110,10 +113,7 @@ class BaseIteratorWorkChain(WorkChain, ABC):
         parsed_list = []
         # Let's iterate over all values so that we can parse them all
         for obj in list_to_parse:
-
-            # If it was a python type, convert it to aiida type (e.g. a node)
-            if not isinstance(obj, Node):
-                obj = to_aiida_type(obj)
+  Line: 146
 
             # If it has just been converted to a node, or it was an unstored node
             # store it so that it gets a pk.
@@ -150,7 +150,7 @@ class BaseIteratorWorkChain(WorkChain, ABC):
             over (str) and each value is a list with all the values to iterate over for
             that parameter. Each value in the list can be either a node (unstored or stored)
             or a simple python object (str, float, int, bool).
-            
+
             Note that each subclass might parse this keys and values differently, so you should
             know how they do it.
             '''
@@ -171,7 +171,7 @@ class BaseIteratorWorkChain(WorkChain, ABC):
             "batch_size",
             valid_type=Int,
             default=lambda: Int(1),
-            help='''The maximum number of simulations that should run at the same time. 
+            help='''The maximum number of simulations that should run at the same time.
             You can set this to a very large number to make sure that all simulations run in
             one single batch if you want.'''
         )
@@ -364,9 +364,9 @@ class InputIterator(BaseIteratorWorkChain):
 
     This class can not be used. However, you don't need to much!
 
-    All you need to provide in a subclass to make use of this iterator is 
+    All you need to provide in a subclass to make use of this iterator is
     the process to run. The way you do this is by setting the `_process_class`
-    variable. See the examples section . Once you have defined the process to run, 
+    variable. See the examples section . Once you have defined the process to run,
     this workchain exposes its inputs and runs the process iteritatively.
 
     The outline of this workchain is exactly the same as `BaseIteratorWorkchain`
@@ -387,7 +387,7 @@ class InputIterator(BaseIteratorWorkChain):
 
         # Submit the process with the modified inputs
         submit(MyProcess, **inputs)
-    
+
     It also gives the possibility to accept iterating over parameters that are not
     directly an input of the process class.
     Therefore, if you want to add extra functionality to it, you probably should be
@@ -506,11 +506,11 @@ class InputIterator(BaseIteratorWorkChain):
 
     def _parse_key(self, key):
         """
-        Uses the opportunity given by BaseIteratorWorkchain to store the input keys 
+        Uses the opportunity given by BaseIteratorWorkchain to store the input keys
         and parsing functions that we are going to use for each parameter through the workchain.
 
         Can be overwritten by child classes, but the default parameter management of this class
-        is quite general and well organized, so consider giving it a try before implementing 
+        is quite general and well organized, so consider giving it a try before implementing
         a different one.
 
         Parameters
@@ -531,7 +531,7 @@ class InputIterator(BaseIteratorWorkChain):
         Parses the value using the parsing function that we have stored for this parameter.
 
         Can be overwritten by child classes, but the default parameter management of this class
-        is quite general and well organized, so consider giving it a try before implementing 
+        is quite general and well organized, so consider giving it a try before implementing
         a different one.
 
         Parameters
@@ -559,10 +559,10 @@ class InputIterator(BaseIteratorWorkChain):
         E.g.:
             if the parameter 'kpoints_whatever' means that you need to parse
             the value into a KpointsData() and set it to the 'kpoints' input,
-            this should return 'kpoints' 
+            this should return 'kpoints'
 
         Can be overwritten by child classes, but the default parameter management of this class
-        is quite general and well organized, so consider giving it a try before implementing 
+        is quite general and well organized, so consider giving it a try before implementing
         a different one.
 
         Parameters
@@ -641,7 +641,7 @@ def set_up_parameters_dict(val, inputs, parameter, input_key, defaults=None):
     inputs: AttributeDict
         all the current inputs, so that we can extract the curren FDFdict.
     parameter: str
-        the name of the fdf flag. Case and hyphen insensitive. 
+        the name of the fdf flag. Case and hyphen insensitive.
     input_key: str
         the input of the fdf dict that should be modified.
     defaults: dict, optional
@@ -654,7 +654,6 @@ def set_up_parameters_dict(val, inputs, parameter, input_key, defaults=None):
     # Get the current FDFdict for the corresponding input
     parameters = getattr(inputs, input_key, DataFactory('dict')())
     parameters = FDFDict(parameters.get_dict())
-
 
     # Set the units for the value if needed
     if isinstance(val, (int, float)) and defaults and "units" in defaults:
@@ -743,16 +742,24 @@ def set_up_kpoint_grid(val, inputs, parameter, input_key='kpoints'):
 SIESTA_ITERATION_PARAMS = (
     (
         "Basis parameters", {
-            "input_key": "basis",
-            "parse_func": set_up_parameters_dict,
-            "condition": lambda parameter: FDFDict.translate_key(parameter).startswith("pao"),
-            "keys": FDFDict({
-                "paobasissize":{'defaults': {
-                    'values_list': ['SZ', 'SZP', 'DZ', 'DZP', 'TZ', 'TZP']
-                }},
-                "paoenergyshift":{'defaults': {
-                    'units': 'Ry'
-                }}
+            "input_key":
+            "basis",
+            "parse_func":
+            set_up_parameters_dict,
+            "condition":
+            lambda parameter: FDFDict.translate_key(parameter).startswith("pao"),
+            "keys":
+            FDFDict({
+                "paobasissize": {
+                    'defaults': {
+                        'values_list': ['SZ', 'SZP', 'DZ', 'DZP', 'TZ', 'TZP']
+                    }
+                },
+                "paoenergyshift": {
+                    'defaults': {
+                        'units': 'Ry'
+                    }
+                }
             })
         }
     ),
@@ -773,13 +780,13 @@ SIESTA_ITERATION_PARAMS = (
             "input_key": "parameters",
             "condition": lambda parameter: True,
             "parse_func": set_up_parameters_dict,
-            "keys": FDFDict({
-                "meshcutoff": {'defaults': {
+            "keys": FDFDict({"meshcutoff": {
+                'defaults': {
                     'units': 'Ry',
                     'init_value': 100,
                     'step': 100
-                }}
-            })
+                }
+            }})
         }
     ),
 )
@@ -789,7 +796,7 @@ class SiestaIterator(InputIterator):
     """
     General iterator for ANY parameter in SIESTA.
 
-    It runs `SiestaBaseWorkChain` iteratively setting the inputs 
+    It runs `SiestaBaseWorkChain` iteratively setting the inputs
     appropiately at each iteration.
 
     With the help of the `SIESTA_ITERATION_PARAMS` dictionary, it decides

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -652,6 +652,7 @@ def set_up_parameters_dict(val, inputs, parameter, input_key, defaults=None):
     parameters = getattr(inputs, input_key, DataFactory('dict')())
     parameters = FDFDict(parameters.get_dict())
 
+
     # Set the units for the value if needed
     if isinstance(val, (int, float)) and defaults and "units" in defaults:
         val = f'{val} {defaults["units"]}'
@@ -739,14 +740,10 @@ def set_up_kpoint_grid(val, inputs, parameter, input_key='kpoints'):
 SIESTA_ITERATION_PARAMS = (
     (
         "Basis parameters", {
-            "input_key":
-            "basis",
-            "parse_func":
-            set_up_parameters_dict,
-            "condition":
-            lambda parameter: FDFDict.translate_key(parameter).startswith("pao"),
-            "keys":
-            FDFDict(
+            "input_key": "basis",
+            "parse_func": set_up_parameters_dict,
+            "condition": lambda parameter: FDFDict.translate_key(parameter).startswith("pao"),
+            "keys": FDFDict(
                 paobasissize={'defaults': {
                     'values_list': ['SZ', 'SZP', 'DZ', 'DZP', 'TZ', 'TZP']
                 }},
@@ -773,11 +770,13 @@ SIESTA_ITERATION_PARAMS = (
             "input_key": "parameters",
             "condition": lambda parameter: True,
             "parse_func": set_up_parameters_dict,
-            "keys": FDFDict(meshcutoff={'defaults': {
-                'units': 'Ry',
-                'init_value': 100,
-                'step': 100
-            }})
+            "keys": FDFDict(
+                meshcutoff={'defaults': {
+                    'units': 'Ry',
+                    'init_value': 100,
+                    'step': 100
+                }}
+            )
         }
     ),
 )


### PR DESCRIPTION
I talked to Emanuele and he gave me some advice on how to develop an Aiida workflow. He also gave me permission to try and develop convergence workflows :)

Right now it is basic stuff, but it works.

There is a base `ConvergenceWorkflow` and then workflows that inherit from it that are more specific (i.e. `MeshCutoffConvergence` and `KpointComponentConvergence`). Finally, there is a `KpointsConvergenceWorkflow` that iterates over k point components to converge them.

Let me know what would you say could be improved.

Some main things that I have thought about are:
- In `ConvergenceWorkflow`, have the ability of running more than one job per iteration.
- Let the convergence criterium be flexible. Let the user pass a function to determine when it has converged. Also have some preset functions for convergence, then the input would be just a string indicating the one that you want to use.
- In `KpointsConvergence`, converge multiple components in parallel.
- Implement the `EnergyShiftConvergence` workflow.
- One final workflow that converges everything (kpoints, mesh cutoff and energy shift).

**EDIT**:
 As Emanuele said when we discussed about this, given the few cases of parameters that should be converged, it was probably not worth it to generalize that much just for that.

Therefore, the fix has been generalizing even more to create Iterator workflows :). Then each convergence workchain is the combination of `BaseConvergencePlugin` and a `Iterator`. (I wanted to define them dinamically, but then saw that aiida doesn't like that).

I saw that `SiestaBaseWorkChain` already involves some kind of iteration, but it seemed to me that the iteration is only meant to restart the same simulation, not to run multiple simulations. Please correct me if I'm wrong.

It may seem like an overkill to generalize as much as I did, but it seems quite powerful to me, I don't know. Now someone with little knowledge of Aiida will be able to launch multiple simulations iterating over a parameter easily. Note that with the `AttributeIterator` one can run the same simulation over different pseudos, pseudo_families, codes (i.e. computers), structures, slurm options, etc. without any further code. This wide range of applications with just a single workflow seems worth it to me.

You will see that there are classes that iterate over specific parameters (i.e. the `MeshCutoffIterator`). An exactly equivalent class can be obtained by passing the appropiate settings, and that's why there are some dictionaries (`_PARAMS`, `_BASIS_PARAMS`, `_ATTRIBUTES`), that define how to get them. I don't know which one of the two ways is better, but I thought there's already probably something like those dictionaries, if not in `aiida_siesta`, in SIESTA itself. Is it the case? With the help of this dictionaries, one can use the high level APIs `iterate` and `converge`:

```python
from aiida_siesta.workflows.converge import converge
from aiida.orm import Str, Code, StructureData, Dict

siesta = Code.get_from_string('siesta@mare')
converge('meshcutoff', code=siesta, structure=StructureData(),
    parameters=Dict(), pseudo_family=Str('Whatever'),
    options=Dict(dict={'resources': {'num_machines': 1, "num_mpiprocs_per_machine": 1}, 'max_wallclock_seconds': 3600}))
```

Giving the possibility to run batches of simulations instead of doing it one by one would still be cool I think. Also, since the values for the parameters are provided by a generator, I would say it would not be very complicated to adapt this to implement "zipped" iterators or the cartesian product between two (or more) variables that need to be iterated, which I believe would be very useful for high-throughput, and for code testing.

**PS**: *Sorry for the long text :)*
