### PR TITLE
Changes in the tkdict module.

### DIFF
--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -175,7 +175,7 @@ class SiestaCalculation(CalcJob):
                 if key == canonical_blocked:
                     raise InputValidationError(
                         "You cannot specify explicitly the '{}' flag in the "
-                        "input parameters".format(input_params.get_untranslated_key(key))
+                        "input parameters".format(input_params.get_last_untranslated_key(key))
                     )
                 if "pao" in key:
                     raise InputValidationError(

--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -175,7 +175,7 @@ class SiestaCalculation(CalcJob):
                 if key == canonical_blocked:
                     raise InputValidationError(
                         "You cannot specify explicitly the '{}' flag in the "
-                        "input parameters".format(input_params.get_last_key(key))
+                        "input parameters".format(input_params.get_untranslated_key(key))
                     )
                 if "pao" in key:
                     raise InputValidationError(

--- a/aiida_siesta/calculations/tkdict.py
+++ b/aiida_siesta/calculations/tkdict.py
@@ -13,43 +13,43 @@ Vladimir Dikan and Alberto Garcia, 2017
 
 """
 
+from abc import abstractmethod
 from collections.abc import MutableMapping
 
 
 class TKDict(MutableMapping):
     """
-    Dictionary-like class that also contains character translation and deletion data.
-    Stores (value, initial-key) tuples accessible by a translated key.
+    Abstract class that mocks a python dictionary but with some translation
+    rules applied to the key of the dictionary.
+    It required the definition of the method `translate_key` that contains the
+    translation rule.
+    Once the translation rule is set. This abstract class take care of all the rest,
+    meaning providing all the methods for the management of the dictionary.
+    Internally, it defines an attribute _storage that is a dictionary
+    with keys the translated key and with value the (value, original-key) tuples.
     """
 
     @classmethod
+    @abstractmethod
     def translate_key(cls, key):
         """ Definition of a rule for key translation. """
-        raise NotImplementedError
 
-    def __init__(self, *args, **kw):
+    def __init__(self, inp_dict=None):  #*args, **kw):
         """
         Create translated-keys-dictionary from initial data.
         If several input keys translate to same string, only first occurrence is saved.
         """
         # _storage is internal dictionary stored as: {<translated_key>: (<value>, <initial_key>), }
         self._storage = {}
-        inp_dict = dict(*args, **kw)
 
-        for inp_key in inp_dict:
-            self[inp_key] = inp_dict[inp_key]
+        if inp_dict:
+            if not isinstance(inp_dict, dict):
+                message = 'invalid argument for `{}`: it only accepts a dictionary'.format(self.__class__.__name__)
+                raise RuntimeError(message)
 
-    def keys(self):
-        """ Return list of last key occurences. """
-        # _storage keys are translated
-        return [self.get_last_key(k) for k in self._storage]
-        # return(self._storage.keys())
-
-    def iterkeys(self):
-        """D.iterkeys() -> an iterator over the keys of D *** UPDATE """
-        for key in self:
-            value, last_key = self._storage[key]  # pylint: disable=unused-variable
-            yield last_key
+        if inp_dict:
+            for inp_key in inp_dict:
+                self[inp_key] = inp_dict[inp_key]
 
     def __setitem__(self, key, value):
         """ Store a (value, initial_key) tuple under translated key. """
@@ -61,44 +61,15 @@ class TKDict(MutableMapping):
     def __getitem__(self, key):
         """ Translate the key, unpack value-tuple and return the value if exists or None. """
         trans_key = self.translate_key(key)
-        try:
-            value, last_key = self._storage[trans_key]  # pylint: disable=unused-variable
-            #self._storage.__setitem__(trans_key, (value, key))
-            return value
-        except KeyError:
-            return None
-
-    def iteritems(self):
-        """D.iteritems() -> an iterator over the (key, value) items of D """
-        for key in self:
-            value, last_key = self._storage[key]
-            yield (last_key, value)
-
-    def items(self):
-        """D.items() -> list of D's (key, value) pairs, as 2-tuples"""
-        return [(self._storage[key][1], self._storage[key][0]) for key in self]
-
-    def get_last_key(self, key):
-        """
-        Translate the key, unpack value-tuple and return
-        the corresponding initial key if exists or None.
-        """
-        trans_key = self.translate_key(key)
-        try:
-            value, last_key = self._storage[trans_key]  # pylint: disable=unused-variable
-            return last_key
-        except KeyError:
-            return None
-
-    def get_filtered_items(self):
-        for k, v in self._storage.items():
-            yield k, v[0]
+        value, last_key = self._storage[trans_key]  # pylint: disable=unused-variable
+        return value
 
     def __delitem__(self, key):
         """ Translate the key, purge value-tuple """
         self._storage.__delitem__(self.translate_key(key))
 
     def __iter__(self):
+        """We iter on the translated keys"""
         return iter(self._storage)
 
     def __len__(self):
@@ -109,6 +80,80 @@ class TKDict(MutableMapping):
 
     def __str__(self):
         return self._storage.__str__()
+
+    def values(self):
+        """
+        Return list of values.
+
+        """
+        return [self[k] for k in self]
+
+    def untranslated_keys(self):
+        """
+        Return a list of last occurencies of the untranslated keys. For each translated_key,
+        it is stored as second entry of the self._storage[translated_key] tuple.
+        """
+        return [self._storage[k][1] for k in self._storage]
+
+    def keys(self):
+        """
+        Return list of translated keys. The self_storage keys are already translated.
+
+        """
+        return self._storage.keys()
+
+    def untranslated_items(self):
+        """
+        Return a list of the items with the last occurencies of the untranslated keys
+        as key.
+        """
+        return [(self._storage[key][1], self._storage[key][0]) for key in self]
+
+    def items(self):
+        """
+        Return a list of the items with the translated key as key.
+
+        """
+        return [(key, self._storage[key][0]) for key in self]
+
+    def translated_dict(self):
+        """
+        Return a dictionary, where the key are the translated keys
+        """
+        new_dict = self._storage.copy()
+
+        for k in self._storage:
+            new_dict[k] = self._storage[k][0]
+
+        return new_dict
+
+    def untranslated_dict(self):
+        """
+        Return a dictionary, where the key are the translated keys
+        """
+        new_dict = {}  #self._storage.copy()
+
+        for k in self._storage:
+            new_dict[self._storage[k][1]] = self._storage[k][0]
+
+        return new_dict
+
+    #Only for back compatibility!!! Does the same job of
+    #items when iterated, but can't be called by itself
+    def get_filtered_items(self):
+        for k, v in self._storage.items():
+            yield k, v[0]
+
+    def get_untranslated_key(self, key):
+        """
+        Translate the key, unpack value-tuple and return
+        the corresponding initial key if exists or None.
+        """
+        trans_key = self.translate_key(key)
+        #try:
+        return self._storage[trans_key][1]
+        #except KeyError:
+        #    return KeyError("Key {} is not defined".format(key))
 
 
 class FDFDict(TKDict):  # pylint: disable=too-many-ancestors

--- a/aiida_siesta/calculations/tkdict.py
+++ b/aiida_siesta/calculations/tkdict.py
@@ -122,27 +122,17 @@ class TKDict(MutableMapping):
         """
         return [(key, self._storage[key][0]) for key in self]
 
-    def dict(self):
+    def get_dict(self):
         """
         Return a dictionary, where the key are the translated keys
         """
-        new_dict = self._storage.copy()
+        return {key: val[0] for key, val in self._storage.items()}
 
-        for k in self._storage:
-            new_dict[k] = self._storage[k][0]
-
-        return new_dict
-
-    def untranslated_dict(self):
+    def get_untranslated_dict(self):
         """
         Return a dictionary, where the key are the translated keys
         """
-        new_dict = {}  #self._storage.copy()
-
-        for k in self._storage:
-            new_dict[self._storage[k][1]] = self._storage[k][0]
-
-        return new_dict
+        return {val[1]: val[0] for val in self._storage.values()}
 
     #Only for back compatibility!!! Does the same job of
     #items when iterated, but can't be called by itself

--- a/tests/calculations/test_fdfdict.py
+++ b/tests/calculations/test_fdfdict.py
@@ -12,4 +12,4 @@ def test_fdfdict():
     f["A-_.B"] = 1
     assert("a_b" in list(f._storage.keys()))
     assert f["a_:.b"] == 1
-    assert f.get_last_key("a::_b") == "A-_.B"
+    assert f.get_untranslated_key("a::_b") == "A-_.B"

--- a/tests/calculations/test_fdfdict.py
+++ b/tests/calculations/test_fdfdict.py
@@ -1,10 +1,22 @@
 #!/usr/bin/env python
+from aiida_siesta.calculations.tkdict import FDFDict
 
-def test_fdfdict():
+
+def test_fdfdict_wrong_argument():
     """
-    Simple test of a FDFDict class instance.
+    Simple test of a FDFDict class instance with an unaccepted
+    argument passed
     """
-    from aiida_siesta.calculations.tkdict import FDFDict
+
+    import pytest
+    with pytest.raises(RuntimeError):
+        f = FDFDict("w")
+
+def test_fdfdict_no_argument():
+    """
+    Simple test of a FDFDict class instance with no
+    argument passed, also tests `get_last_untranslated_key`
+    """
 
     f = FDFDict()
 
@@ -12,4 +24,40 @@ def test_fdfdict():
     f["A-_.B"] = 1
     assert("a_b" in list(f._storage.keys()))
     assert f["a_:.b"] == 1
-    assert f.get_untranslated_key("a::_b") == "A-_.B"
+    assert f.get_last_untranslated_key("a::_b") == "A-_.B"
+
+def test_fdfdict():
+    """
+    Simple test of a FDFDict class instance with a dictionary passed
+    """
+
+    inp_dict = {"w":3,"e":4,"w--":5}
+    
+    f = FDFDict(inp_dict)
+
+    assert f["w"] == 5
+    
+    f["e-"] = 4
+    assert f.get_last_untranslated_key("e") == "e-"
+
+    assert "w" in f
+
+    for i in f:
+        assert i in ["w","e"]
+
+def test_fdfdict_methods():
+    """
+    Simple test of a FDFDict class instance with a dictionary passed
+    """
+
+    inp_dict = {"w":3,"e":4,"w--":5}
+
+    f = FDFDict(inp_dict)
+
+    assert sorted(f.values()) == sorted([5,4])
+    assert sorted(f.keys()) == sorted(["w","e"])
+    assert sorted(f.untranslated_keys()) == sorted(["w--","e"])
+    assert sorted(f.items()) == sorted([("w",5),("e",4)])
+    assert sorted(f.untranslated_items()) == sorted([("w--",5),("e",4)])
+    assert f.dict() == {"w":5,"e":4}
+    assert f.untranslated_dict() == {"w--":5,"e":4}

--- a/tests/calculations/test_fdfdict.py
+++ b/tests/calculations/test_fdfdict.py
@@ -59,5 +59,5 @@ def test_fdfdict_methods():
     assert sorted(f.untranslated_keys()) == sorted(["w--","e"])
     assert sorted(f.items()) == sorted([("w",5),("e",4)])
     assert sorted(f.untranslated_items()) == sorted([("w--",5),("e",4)])
-    assert f.dict() == {"w":5,"e":4}
-    assert f.untranslated_dict() == {"w--":5,"e":4}
+    assert f.get_dict() == {"w":5,"e":4}
+    assert f.get_untranslated_dict() == {"w--":5,"e":4}


### PR DESCRIPTION
Changes:

* Now the TKDict is an abstract class. Subclasses needs only to define "`translate_key`.
* It can be instantiated only passing a dictionary or nothing.
* Now the behavior is more similar to a normal dictionary, where the keys are translated keys according to the translation rule. In other words, the class has methods items(), keys() that show the translated keys. In addition there are `untranslated_keys()` and `untranslated_items()` methods that return the untranslated keys (the last defined).
* I changed the `get_last_key` to ` get_untranslated_key`, that clarifies more the scope of the method.
* I also added two methods to get a dictionary with translated keys and one with untranslated keys. I think this is necessary because sometimes external functions (like `Dict` or the context of WorkChains) require a dict type.
* It fixes the issue #47 
* The setting and getting behaviors remain the same.

Let me know if this is ok in your opinion, @vdikan and @pfebrer96