### PR TITLE
Test work chains

### DIFF
--- a/aiida_siesta/workflows/base.py
+++ b/aiida_siesta/workflows/base.py
@@ -226,11 +226,13 @@ class SiestaBaseWorkChain(BaseRestartWorkChain):
         If an error in the parsing of bands occours in the SiestaCalculation (node here), we expose all
         the output ports node that have been produced (SiestaCalculation is designed to produce the
         output_parameter and stress/forcess port before the check on the bands outputs) and then we
-        stop the workchain with a specific error code.
+        stop the workchain with a specific error code. We exclude the "retrieved" output port as
+        it refers only to the underline calculation, not to the WorkChain itself.
         """
         for name in node.outputs:
-            output = node.get_outgoing(link_label_filter=name).one().node
-            self.out(name, output)
+            if name != "retrieved":
+                output = node.get_outgoing(link_label_filter=name).one().node
+                self.out(name, output)
 
         return ProcessHandlerReport(True, self.exit_codes.ERROR_BANDS_PARSING)
 

--- a/aiida_siesta/workflows/eos.py
+++ b/aiida_siesta/workflows/eos.py
@@ -265,6 +265,9 @@ class EqOfStateFixedCellShape(WorkChain):
         return ToContext(**calcs)  #Here it waits
 
     def return_results(self):
+
+        from aiida.engine import ExitCode
+
         self.report('All 7 calculations finished. Post process starts')
         collectwcinfo = {}
         for label in self.ctx.scales:
@@ -293,6 +296,8 @@ class EqOfStateFixedCellShape(WorkChain):
             self.report("WARNING: Birch-Murnaghan fit failed, check your results_dict['eos_data']")
 
         self.report('End of EqOfStateFixedCellShape Workchain')
+
+        return ExitCode(0)
 
     @classproperty
     def inputs_generator(cls):  # pylint: disable=no-self-argument,no-self-use

--- a/aiida_siesta/workflows/stm.py
+++ b/aiida_siesta/workflows/stm.py
@@ -285,17 +285,18 @@ class SiestaSTMWorkChain(WorkChain):
 
         from aiida.engine import ExitCode
 
-        if not self.ctx.siesta_ldos.is_finished_ok:
-            return self.exit_codes.ERROR_STM_PLUGIN
-
         if self.ctx.spinstm == "non-collinear":
             cumarray = {}
             for spinmod in ("q", "x", "y", "z"):
                 stmnode = self.ctx[spinmod]
+                if not stmnode.is_finished_ok:
+                    return self.exit_codes.ERROR_STM_PLUGIN
                 cumarray[spinmod] = stmnode.outputs.stm_array
             stm_array = create_non_coll_array(**cumarray)
             self.out('stm_array', stm_array)
         else:
+            if not self.ctx.stm_calc.is_finished_ok:
+                return self.exit_codes.ERROR_STM_PLUGIN
             stm_plot_calc = self.ctx.stm_calc
             stm_array = stm_plot_calc.outputs.stm_array
             self.out('stm_array', stm_array)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def generate_psml_data():
 def generate_structure():
     """Return a `StructureData` representing bulk silicon."""
 
-    def _generate_structure():
+    def _generate_structure(scale=None):
         """Return a `StructureData` representing bulk silicon."""
         from aiida.orm import StructureData
 
@@ -189,6 +189,13 @@ def generate_structure():
         structure = StructureData(cell=cell)
         structure.append_atom(position=(0., 0., 0.), symbols='Si', name='Si')
         structure.append_atom(position=(param / 4., param / 4., param / 4.), symbols='Si', name='SiDiff')
+
+        if scale:
+            the_ase = structure.get_ase()
+            new_ase = the_ase.copy()
+            new_ase.set_cell(the_ase.get_cell() * float(scale), scale_atoms=True)
+            new_structure = StructureData(ase=new_ase)
+            structure = new_structure
 
         return structure
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,14 +335,12 @@ def generate_wc_job_node():
                 flat_inputs.append((prefix + key, value))
         return flat_inputs
 
-    def _generate_wc_job_node(entry_point_name, computer, inputs=None, attributes=None):
-        """Fixture to generate a mock `CalcJobNode` for testing parsers.
-        :param entry_point_name: entry point name of the calculation class
+    def _generate_wc_job_node(entry_point_name, computer, inputs=None):
+        """Fixture to generate a mock `WorkChainNode` for testing parsers.
+        :param entry_point_name: entry point name of the workchain class
         :param computer: a `Computer` instance
-        :param test_name: relative path of directory with test output files in the `fixtures/{entry_point_name}` folder.
         :param inputs: any optional nodes to add as input links to the corrent CalcJobNode
-        :param attributes: any optional attributes to set on the node
-        :return: `CalcJobNode` instance with an attached `FolderData` as the `retrieved` node
+        :return: `WorkChainNode` instance attached inputs if `inputs` is defined
         """
         from aiida import orm
         from aiida.common import LinkType
@@ -350,24 +348,12 @@ def generate_wc_job_node():
 
         entry_point = format_entry_point_string('aiida.workflows', entry_point_name)
 
-        node = orm.CalcJobNode(computer=computer, process_type=entry_point)
-        #This should be defined through input line
-        #node.set_attribute('input_filename', 'aiida.fdf')
-        #node.set_attribute('output_filename', 'aiida.out')
-        #node.set_attribute('prefix', 'aiida')
-        node.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
-        node.set_option('max_wallclock_seconds', 1800)
-
-        if attributes:
-            node.set_attribute_many(attributes)
+        node = orm.WorkChainNode(computer=computer, process_type=entry_point)
         
-        #What inputs do we need? I don't think it checks the mandatory inputs,
-        #for instance the pseudo is not defined in quantum espresso.
-        #Probably only the ones that trigger a particular parsing? Or not even.
         if inputs:
             for link_label, input_node in flatten_inputs(inputs):
                 input_node.store()
-                node.add_incoming(input_node, link_type=LinkType.INPUT_CALC, link_label=link_label)
+                node.add_incoming(input_node, link_type=LinkType.INPUT_WORK, link_label=link_label)
 
         node.store()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,3 +297,25 @@ def generate_remote_data():
         return remote
 
     return _generate_remote_data
+
+@pytest.fixture
+def generate_workchain():
+    """Generate an instance of a `WorkChain`."""
+
+    def _generate_workchain(entry_point, inputs):
+        """Generate an instance of a `WorkChain` with the given entry point and inputs.
+        :param entry_point: entry point name of the work chain subclass.
+        :param inputs: inputs to be passed to process construction.
+        :return: a `WorkChain` instance.
+        """
+        from aiida.engine.utils import instantiate_process
+        from aiida.manage.manager import get_manager
+        from aiida.plugins import WorkflowFactory
+
+        process_class = WorkflowFactory(entry_point)
+        runner = get_manager().get_runner()
+        process = instantiate_process(runner, process_class, **inputs)
+
+        return process
+
+    return _generate_workchain

--- a/tests/workflows/test_bandgap.py
+++ b/tests/workflows/test_bandgap.py
@@ -66,3 +66,25 @@ def test_setup(aiida_profile, generate_workchain_bandgap):
     process.prepare_inputs()
 
     assert isinstance(process.ctx.inputs, dict)
+
+def test_postprocess(aiida_profile, generate_workchain_bandgap):
+#    """Test `BangapWorkChain.setup`."""
+#
+    process = generate_workchain_bandgap(bands=True)
+    process.out('output_parameters', orm.Dict(dict={'E_Fermi' : -1}))
+    bands = orm.BandsData()
+    bkp = process.inputs.bandskpoints
+    bands.set_kpoints(bkp.get_kpoints(cartesian=True))
+    #bands.labels = bkp.labels
+    import numpy as np
+    bands.set_bands(np.array([[-2,1,3],[-2,1,3],[-2,1,3]]), units="eV")
+    process.out('bands', bands)
+    process.postprocess()
+
+    res = process.outputs["band_gap_info"]
+    assert isinstance(res,orm.Dict)
+    assert res['is_insulator']
+    assert res['band_gap'] == 3.0
+
+    #assert isinstance(process.ctx.inputs, dict)
+

--- a/tests/workflows/test_bandgap.py
+++ b/tests/workflows/test_bandgap.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env runaiida
+import pytest
+from aiida import orm
+
+
+@pytest.fixture
+def generate_workchain_bandgap(generate_psml_data, fixture_code, fixture_localhost, generate_workchain, 
+        generate_structure, generate_param, generate_basis, generate_kpoints_mesh,
+        generate_calc_job_node, generate_parser):
+    """Generate an instance of a `BandgapWorkChain`."""
+
+    def _generate_workchain_bandgap(bands=False):
+
+        entry_point_wc = 'siesta.bandgap'
+        entry_point_code = 'siesta.siesta'
+
+        psml = generate_psml_data('Si')
+
+        structure = generate_structure()
+
+        inputs = {
+            'code': fixture_code(entry_point_code),
+            'structure': structure,
+            'kpoints': generate_kpoints_mesh(2),
+            'parameters': generate_param(),
+            'basis': generate_basis(),
+            'pseudos': {
+                'Si': psml,
+                'SiDiff': psml
+            },
+            'options': orm.Dict(dict={
+               'resources': {'num_machines': 1  },
+               'max_wallclock_seconds': 1800,
+               'withmpi': False,
+               })
+        }
+
+        if bands:
+            bandskpoints = orm.KpointsData()
+            kpp = [(0.500,  0.250, 0.750), (0.500,  0.500, 0.500), (0., 0., 0.)]
+            bandskpoints.set_cell(structure.cell, structure.pbc)
+            bandskpoints.set_kpoints(kpp)
+            inputs["bandskpoints"] = bandskpoints
+
+
+        process = generate_workchain(entry_point_wc, inputs)
+
+        return process
+
+    return _generate_workchain_bandgap
+
+def test_setup_fail(aiida_profile, generate_workchain_bandgap):
+    """Test `BangapWorkChain.setup`."""
+    with pytest.raises(ValueError):
+        process = generate_workchain_bandgap()
+        process.preprocess()
+        process.setup()
+        process.prepare_inputs()
+
+def test_setup(aiida_profile, generate_workchain_bandgap):
+    """Test `BangapWorkChain.setup`."""
+    
+    process = generate_workchain_bandgap(bands=True)
+    process.preprocess()
+    process.setup()
+    process.prepare_inputs()
+
+    assert isinstance(process.ctx.inputs, dict)

--- a/tests/workflows/test_base.py
+++ b/tests/workflows/test_base.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env runaiida
+import pytest
+from plumpy import ProcessState
+from aiida import orm
+from aiida.common import LinkType
+from aiida.common import AttributeDict
+from aiida.engine import ProcessHandlerReport
+from aiida_siesta.calculations.siesta import SiestaCalculation
+from aiida_siesta.workflows.base import SiestaBaseWorkChain
+
+@pytest.fixture
+def generate_workchain_base(generate_psml_data, fixture_code, fixture_localhost, generate_workchain, 
+        generate_structure, generate_param, generate_basis, generate_kpoints_mesh,
+        generate_calc_job_node, generate_parser):
+    """Generate an instance of a `SiestaBaseWorkChain`."""
+
+    def _generate_workchain_base(exit_code=None):
+
+        entry_point_wc = 'siesta.base'
+        entry_point_code = 'siesta.siesta'
+
+        psml = generate_psml_data('Si')
+
+        inputs = {
+            'code': fixture_code(entry_point_code),
+            'structure': generate_structure(),
+            'kpoints': generate_kpoints_mesh(2),
+            'parameters': generate_param(),
+            'basis': generate_basis(),
+            'pseudos': {
+                'Si': psml,
+                'SiDiff': psml
+            },
+            'options': orm.Dict(dict={
+               'resources': {'num_machines': 1  },
+               'max_wallclock_seconds': 1800,
+               'withmpi': False,
+               })
+        }
+
+        process = generate_workchain(entry_point_wc, inputs)
+
+        if exit_code is not None:
+            inputs2 = AttributeDict({'structure': generate_structure()})
+            attributes=AttributeDict({'input_filename':'aiida.fdf', 'output_filename':'aiida.out', 'prefix':'aiida'})
+            node = generate_calc_job_node("siesta.siesta", fixture_localhost, "default", inputs2, attributes)
+            out_par = orm.Dict(dict={"variable_geometry":False})
+            out_par.add_incoming(node, link_type=LinkType.CREATE, link_label='output_parameters')
+            out_par.store()
+            node.logger.error("Error in split_norm option. Minimum value is 1")
+            node.set_process_state(ProcessState.FINISHED)
+            node.set_exit_status(exit_code.status)
+
+            process.ctx.iteration = 1
+            process.ctx.children = [node]
+
+        return process
+
+    return _generate_workchain_base
+
+def test_setup(aiida_profile, generate_workchain_base):
+    """Test `SiestaBaseWorkChain.setup`."""
+    process = generate_workchain_base()
+    process.setup()
+    process.prepare_inputs()
+
+    print(process)
+
+    assert isinstance(process.ctx.inputs, dict)
+
+    
+def test_handle_error_geom_not_conv(aiida_profile, generate_workchain_base):
+    """Test `SiestaBaseWorkChain.handle_error_geom_not_conv`."""
+    process = generate_workchain_base(exit_code=SiestaCalculation.exit_codes.GEOM_NOT_CONV)
+    process.setup()
+    process.prepare_inputs()
+
+    result = process.handle_error_geom_not_conv(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    #assert result.exit_code == SiestaBaseWorkChain.exit_codes.GEOM_NOT_CONV
+
+    #result = process.inspect_process()
+    #assert result == PwBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
+
+def test_handle_error_scf_not_conv(aiida_profile, generate_workchain_base):
+    """Test `SiestaBaseWorkChain.handle_error_scf_not_conv`."""
+    process = generate_workchain_base(exit_code=SiestaCalculation.exit_codes.SCF_NOT_CONV)
+    process.setup()
+    process.prepare_inputs()
+
+    result = process.handle_error_scf_not_conv(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    #assert result.exit_code == SiestaBaseWorkChain.exit_codes.GEOM_NOT_CONV
+
+    #result = process.inspect_process()
+    #assert result == PwBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
+
+
+def test_handle_error_basis_pol(aiida_profile, generate_workchain_base):
+    """Test `SiestaBaseWorkChain.handle_error_basis_pol`."""
+    process = generate_workchain_base(exit_code=SiestaCalculation.exit_codes.BASIS_POLARIZ)
+    process.setup()
+    process.prepare_inputs()
+
+    result = process.handle_error_basis_pol(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code == SiestaBaseWorkChain.exit_codes.ERROR_BASIS_POL
+
+
+def test_handle_error_bands(aiida_profile, generate_workchain_base):
+    """Test `SiestaBaseWorkChain.handle_error_bands`."""
+    process = generate_workchain_base(exit_code=SiestaCalculation.exit_codes.BANDS_PARSE_FAIL)
+    process.setup()
+    process.prepare_inputs()
+
+    node = process.ctx.children[-1]
+
+    result = process.handle_error_bands(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+    assert result.exit_code == SiestaBaseWorkChain.exit_codes.ERROR_BANDS_PARSING
+
+    #result = process.inspect_process()
+    #assert result == PwBaseWorkChain.exit_codes.ERROR_UNRECOVERABLE_FAILURE
+
+
+def test_handle_error_split_norm(aiida_profile, generate_workchain_base):
+    """Test `SiestaBaseWorkChain.handle_error_split_norm`."""
+    process = generate_workchain_base(exit_code=SiestaCalculation.exit_codes.SPLIT_NORM)
+    process.setup()
+    process.prepare_inputs()
+
+    result = process.handle_error_split_norm(process.ctx.children[-1])
+    assert isinstance(result, ProcessHandlerReport)
+    assert result.do_break
+

--- a/tests/workflows/test_eos.py
+++ b/tests/workflows/test_eos.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env runaiida
 import pytest
+from plumpy import ProcessState
+from aiida.engine import ExitCode
 from aiida import orm
-
+from aiida.common import (LinkType, AttributeDict)
 
 @pytest.fixture
 def generate_workchain_eos(generate_psml_data, fixture_code, fixture_localhost, generate_workchain, 
@@ -42,10 +44,39 @@ def generate_workchain_eos(generate_psml_data, fixture_code, fixture_localhost, 
     return _generate_workchain_eos
 
 
-def test_setup(aiida_profile, generate_workchain_eos):
+def test_setup_run(aiida_profile, generate_workchain_eos):
     """Test `EoSFixedCellShape`."""
     
     process = generate_workchain_eos()
     process.initio()
 
     assert isinstance(process.ctx.s0, orm.StructureData)
+
+    process.run_base_wcs()
+
+
+def test_results(aiida_profile, generate_workchain_eos,
+        generate_wc_job_node, generate_structure, fixture_localhost):
+
+    process = generate_workchain_eos()
+    process.initio()
+
+    values=[-13,-18,-21,-22,-21,-18,-13]
+
+    for ind in range(len(process.ctx.scales)):
+        inputs = AttributeDict({
+            'structure': generate_structure(scale=process.ctx.scales[ind]),
+            })
+        basewc = generate_wc_job_node("siesta.base", fixture_localhost, inputs)
+        basewc.set_process_state(ProcessState.FINISHED)
+        basewc.set_exit_status(ExitCode(0).status)
+        out_par = orm.Dict(dict={"E_KS":values[ind],"E_KS_units":"eV"})
+        out_par.store()
+        out_par.add_incoming(basewc, link_type=LinkType.RETURN, link_label='output_parameters')
+        process.ctx[str(process.ctx.scales[ind])] = basewc
+
+    result = process.return_results()
+
+    assert result == ExitCode(0)
+    assert isinstance(process.outputs["results_dict"], orm.Dict)
+    assert (process.outputs["results_dict"]["fit_res"]['Vo(ang^3/atom)'] > 20)

--- a/tests/workflows/test_eos.py
+++ b/tests/workflows/test_eos.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env runaiida
+import pytest
+from aiida import orm
+
+
+@pytest.fixture
+def generate_workchain_eos(generate_psml_data, fixture_code, fixture_localhost, generate_workchain, 
+        generate_structure, generate_param, generate_basis, generate_kpoints_mesh,
+        generate_calc_job_node, generate_parser):
+    """Generate an instance of a `BandgapWorkChain`."""
+
+    def _generate_workchain_eos():
+
+        entry_point_wc = 'siesta.eos'
+        entry_point_code = 'siesta.siesta'
+
+        psml = generate_psml_data('Si')
+
+        structure = generate_structure()
+
+        inputs = {
+            'code': fixture_code(entry_point_code),
+            'structure': structure,
+            'kpoints': generate_kpoints_mesh(2),
+            'parameters': generate_param(),
+            'basis': generate_basis(),
+            'pseudos': {
+                'Si': psml,
+                'SiDiff': psml
+            },
+            'options': orm.Dict(dict={
+               'resources': {'num_machines': 1  },
+               'max_wallclock_seconds': 1800,
+               'withmpi': False,
+               })
+        }
+
+        process = generate_workchain(entry_point_wc, inputs)
+
+        return process
+
+    return _generate_workchain_eos
+
+
+def test_setup(aiida_profile, generate_workchain_eos):
+    """Test `EoSFixedCellShape`."""
+    
+    process = generate_workchain_eos()
+    process.initio()
+
+    assert isinstance(process.ctx.s0, orm.StructureData)

--- a/tests/workflows/test_stm.py
+++ b/tests/workflows/test_stm.py
@@ -52,7 +52,7 @@ def generate_workchain_stm(generate_psml_data, fixture_code, generate_workchain,
     return _generate_workchain_stm
 
 
-def test_setup_end_error_stm(aiida_profile, generate_workchain_stm, 
+def test_setup_mainrun_errorbasewc(aiida_profile, generate_workchain_stm, 
         generate_wc_job_node, fixture_localhost):
     """Test `SiestaSTMWorkChain`."""
     
@@ -62,15 +62,93 @@ def test_setup_end_error_stm(aiida_profile, generate_workchain_stm,
     assert process.ctx.spinstm == "none"
     assert not process.ctx.ldosdefinedinparam
 
+    process.run_siesta_wc()
+
+    #Here we could check that process.run_siesta_wc() returns ToContext(workchain_base=running)
+
+    #Fake the base siesta wc in context
+    first_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
+    first_basewc.set_process_state(ProcessState.FINISHED)
+    #Just like this, the exit status in not zero, therefore not finished_ok
+    #It will allow to check error in next step
+    process.ctx.workchain_base = first_basewc
+
+    result = process.run_siesta_with_ldos()
+
+    assert result == SiestaSTMWorkChain.exit_codes.ERROR_BASE_WC
+    
+def test_runldos_errorldos(aiida_profile, generate_workchain_stm, generate_psml_data,
+        generate_wc_job_node, fixture_localhost, fixture_code, generate_structure):
+
+    process = generate_workchain_stm()
+    process.checks()
+
+    #Fake the base siesta wc in context, now with some inputs
+    psml = generate_psml_data('Si')
+    inputs = AttributeDict({
+        'structure': generate_structure(),
+        'code': fixture_code("siesta.siesta"),
+        'parameters': orm.Dict(dict={"sm":"sm"}),
+        'options': orm.Dict(dict={'resources': {'num_machines': 1  },'max_wallclock_seconds': 1800,'withmpi': False}),
+        'pseudos': {'Si': psml,'SiDiff': psml},
+        })
+    first_basewc = generate_wc_job_node("siesta.base", fixture_localhost, inputs)
+    first_basewc.set_process_state(ProcessState.FINISHED)
+    first_basewc.set_exit_status(ExitCode(0).status)
+    #Now is_finished_ok, next step will submit ldos calc
+    #Also needed to fake outputs ports of the basewc: remote_folder and output_parameters
+    #It is different respect to a CalcJob, nodes has to be stored before and link is "RETURN"
+    remote_folder = orm.RemoteData(computer=fixture_localhost, remote_path='/tmp')
+    remote_folder.store()
+    remote_folder.add_incoming(first_basewc, link_type=LinkType.RETURN, link_label='remote_folder')
+    out_par = orm.Dict(dict={"E_Fermi":-1})
+    out_par.store()
+    out_par.add_incoming(first_basewc, link_type=LinkType.RETURN, link_label='output_parameters')
+    process.ctx.workchain_base = first_basewc
+
+    process.run_siesta_with_ldos()
+
+    #Here we might check ToContext(siesta_ldos=running)
+
     ldos_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
     ldos_basewc.set_process_state(ProcessState.FINISHED)
-    #Just like this, the exit status in not zero, therefore not finished_ok
-    #ldos_basewc.set_exit_status(ExitCode(0).status)
+    #We don't set exit status so that if appears as not is_finished_ok
     process.ctx.siesta_ldos = ldos_basewc
+
+    result = process.run_stm()
+
+    assert result == SiestaSTMWorkChain.exit_codes.ERROR_LDOS_WC
+
+def test_runstm_failstm(aiida_profile, generate_workchain_stm, generate_wc_job_node, 
+         generate_calc_job_node, fixture_localhost):
+
+    process = generate_workchain_stm()
+    process.checks()
+
+    ldos_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
+    ldos_basewc.set_process_state(ProcessState.FINISHED)
+    ldos_basewc.set_exit_status(ExitCode(0).status)
+    #Now is_finished_ok, but need to set outputs
+    remote_folder = orm.RemoteData(computer=fixture_localhost, remote_path='/tmp')
+    remote_folder.store()
+    remote_folder.add_incoming(ldos_basewc, link_type=LinkType.RETURN, link_label='remote_folder')
+    process.ctx.siesta_ldos = ldos_basewc
+    
+    process.run_stm()
+
+    #Fake the stm calculation
+    name = 'default'
+    entry_point_calc_job = 'siesta.stm'
+    inputs = AttributeDict({
+        'spin_option' : orm.Str("q")
+    })
+    attributes=AttributeDict({'input_filename':'stm.in', 'output_filename':'stm.out'})
+    stm_node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs, attributes)
+    stm_node.set_process_state(ProcessState.FINISHED)
+    process.ctx.stm_calc = stm_node
 
     result = process.run_results()
 
-    #assert not process.is_finished_ok
     assert result == SiestaSTMWorkChain.exit_codes.ERROR_STM_PLUGIN
 
 
@@ -81,12 +159,6 @@ def test_outputs(aiida_profile, generate_workchain_stm, generate_wc_job_node,
     process = generate_workchain_stm()
     process.checks()
 
-    ldos_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
-    ldos_basewc.set_process_state(ProcessState.FINISHED)
-    #Now we put the exit code finished_ok
-    ldos_basewc.set_exit_status(ExitCode(0).status)
-    process.ctx.siesta_ldos = ldos_basewc
-
     name = 'default'
     entry_point_calc_job = 'siesta.stm'
     inputs = AttributeDict({
@@ -94,6 +166,8 @@ def test_outputs(aiida_profile, generate_workchain_stm, generate_wc_job_node,
     })
     attributes=AttributeDict({'input_filename':'stm.in', 'output_filename':'stm.out'})
     stm_node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs, attributes)
+    stm_node.set_process_state(ProcessState.FINISHED)
+    stm_node.set_exit_status(ExitCode(0).status)
     stm_array = orm.ArrayData()
     stm_array.add_incoming(stm_node, link_type=LinkType.CREATE, link_label='stm_array')
     stm_array.store()
@@ -101,8 +175,8 @@ def test_outputs(aiida_profile, generate_workchain_stm, generate_wc_job_node,
 
     first_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
     out_par = orm.Dict(dict={"variable_geometry":False})
-    out_par.add_incoming(first_basewc, link_type=LinkType.CREATE, link_label='output_parameters')
     out_par.store()
+    out_par.add_incoming(first_basewc, link_type=LinkType.RETURN, link_label='output_parameters')
     process.ctx.workchain_base = first_basewc
 
     result = process.run_results()

--- a/tests/workflows/test_stm.py
+++ b/tests/workflows/test_stm.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env runaiida
 import pytest
+from plumpy import ProcessState
+from aiida.engine import ExitCode
 from aiida import orm
-
+from aiida.common import (LinkType, AttributeDict)
+from aiida_siesta.workflows.stm import SiestaSTMWorkChain
 
 @pytest.fixture
-def generate_workchain_stm(generate_psml_data, fixture_code, fixture_localhost, generate_workchain, 
+def generate_workchain_stm(generate_psml_data, fixture_code, generate_workchain, 
         generate_structure, generate_param, generate_basis, generate_kpoints_mesh,
         generate_calc_job_node, generate_parser):
     """Generate an instance of a `BandgapWorkChain`."""
@@ -49,11 +52,61 @@ def generate_workchain_stm(generate_psml_data, fixture_code, fixture_localhost, 
     return _generate_workchain_stm
 
 
-def test_setup(aiida_profile, generate_workchain_stm):
+def test_setup_end_error_stm(aiida_profile, generate_workchain_stm, 
+        generate_wc_job_node, fixture_localhost):
     """Test `SiestaSTMWorkChain`."""
     
     process = generate_workchain_stm()
     process.checks()
 
-#    assert isinstance(process.ctx.s0, orm.StructureData)
+    assert process.ctx.spinstm == "none"
+    assert not process.ctx.ldosdefinedinparam
+
+    ldos_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
+    ldos_basewc.set_process_state(ProcessState.FINISHED)
+    #Just like this, the exit status in not zero, therefore not finished_ok
+    #ldos_basewc.set_exit_status(ExitCode(0).status)
+    process.ctx.siesta_ldos = ldos_basewc
+
+    result = process.run_results()
+
+    #assert not process.is_finished_ok
+    assert result == SiestaSTMWorkChain.exit_codes.ERROR_STM_PLUGIN
+
+
+def test_outputs(aiida_profile, generate_workchain_stm, generate_wc_job_node, 
+         generate_calc_job_node, fixture_localhost):
+    """Test `SiestaSTMWorkChain`."""
+
+    process = generate_workchain_stm()
+    process.checks()
+
+    ldos_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
+    ldos_basewc.set_process_state(ProcessState.FINISHED)
+    #Now we put the exit code finished_ok
+    ldos_basewc.set_exit_status(ExitCode(0).status)
+    process.ctx.siesta_ldos = ldos_basewc
+
+    name = 'default'
+    entry_point_calc_job = 'siesta.stm'
+    inputs = AttributeDict({
+        'spin_option' : orm.Str("q")
+    })
+    attributes=AttributeDict({'input_filename':'stm.in', 'output_filename':'stm.out'})
+    stm_node = generate_calc_job_node(entry_point_calc_job, fixture_localhost, name, inputs, attributes)
+    stm_array = orm.ArrayData()
+    stm_array.add_incoming(stm_node, link_type=LinkType.CREATE, link_label='stm_array')
+    stm_array.store()
+    process.ctx.stm_calc = stm_node
+
+    first_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
+    out_par = orm.Dict(dict={"variable_geometry":False})
+    out_par.add_incoming(first_basewc, link_type=LinkType.CREATE, link_label='output_parameters')
+    out_par.store()
+    process.ctx.workchain_base = first_basewc
+
+    result = process.run_results()
+
+    assert result == ExitCode(0)
+    assert isinstance(process.outputs["stm_array"], orm.ArrayData)
 

--- a/tests/workflows/test_stm.py
+++ b/tests/workflows/test_stm.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env runaiida
+import pytest
+from aiida import orm
+
+
+@pytest.fixture
+def generate_workchain_stm(generate_psml_data, fixture_code, fixture_localhost, generate_workchain, 
+        generate_structure, generate_param, generate_basis, generate_kpoints_mesh,
+        generate_calc_job_node, generate_parser):
+    """Generate an instance of a `BandgapWorkChain`."""
+
+    def _generate_workchain_stm():
+
+        entry_point_code_siesta = 'siesta.siesta'
+        entry_point_code = 'siesta.stm'
+        entry_point_wc = 'siesta.stm'
+
+        psml = generate_psml_data('Si')
+
+        structure = generate_structure()
+
+        inputs = {
+            'code': fixture_code(entry_point_code_siesta),
+            'stm_code' : fixture_code(entry_point_code),
+            'stm_mode' : orm.Str("constant-height"),
+            'stm_spin' : orm.Str("none"),
+            'stm_value' : orm.Float(1),
+            'emin' : orm.Float(-1),
+            'emax' : orm.Float(1),
+            'structure': structure,
+            'kpoints': generate_kpoints_mesh(2),
+            'parameters': generate_param(),
+            'basis': generate_basis(),
+            'pseudos': {
+                'Si': psml,
+                'SiDiff': psml
+            },
+            'options': orm.Dict(dict={
+               'resources': {'num_machines': 1  },
+               'max_wallclock_seconds': 1800,
+               'withmpi': False,
+               })
+        }
+
+        process = generate_workchain(entry_point_wc, inputs)
+
+        return process
+
+    return _generate_workchain_stm
+
+
+def test_setup(aiida_profile, generate_workchain_stm):
+    """Test `SiestaSTMWorkChain`."""
+    
+    process = generate_workchain_stm()
+    process.checks()
+
+#    assert isinstance(process.ctx.s0, orm.StructureData)
+

--- a/tests/workflows/utils/test_inputs_generators.py
+++ b/tests/workflows/utils/test_inputs_generators.py
@@ -19,6 +19,70 @@ def test_baseworkchain_inpgen(aiida_profile, fixture_code, generate_structure):
     code.store()
     calc_engines = {"siesta": {'code': code.uuid, 'options': {"resources": {"num_mpiprocs_per_machine": 1}, "max_wallclock_seconds": 360}}} 
 
-    build = inp_gen.get_filled_builder(structure, calc_engines, protocol)
+    build = inp_gen.get_filled_builder(structure, calc_engines, protocol, spin="polarized")
+
+    assert "parameters" in build
+
+def test_bandgapworkchain_inpgen(aiida_profile, fixture_code, generate_structure):
+    """Test the validation of subclasses of `InputsGenerator`."""
+
+    #Here I fake the pseudofamilies
+    PsmlFamily.objects.get_or_create("nc-sr-04_pbe_standard_psml")
+    PsmlFamily.objects.get_or_create("nc-sr-04_pbe_stringent_psml")
+
+    from aiida_siesta.workflows.utils.inputs_generators import BandgapWorkChainInputsGenerator
+
+    inp_gen = BandgapWorkChainInputsGenerator(WorkflowFactory("siesta.bandgap"))
+    structure = generate_structure()
+    protocol = inp_gen.get_default_protocol_name()
+    code = fixture_code("siesta.siesta")
+    code.store()
+    calc_engines = {"siesta": {'code': code.uuid, 'options': {"resources": {"num_mpiprocs_per_machine": 1}, "max_wallclock_seconds": 360}}}
+
+    build = inp_gen.get_filled_builder(structure, calc_engines, protocol, bands_path_generator="seekpath")
+
+    assert "parameters" in build
+
+def test_eosworkchain_inpgen(aiida_profile, fixture_code, generate_structure):
+    """Test the validation of subclasses of `InputsGenerator`."""
+
+    #Here I fake the pseudofamilies
+    PsmlFamily.objects.get_or_create("nc-sr-04_pbe_standard_psml")
+    PsmlFamily.objects.get_or_create("nc-sr-04_pbe_stringent_psml")
+
+    from aiida_siesta.workflows.utils.inputs_generators import EosWorkChainInputsGenerator
+
+    inp_gen = EosWorkChainInputsGenerator(WorkflowFactory("siesta.eos"))
+    structure = generate_structure()
+    protocol = inp_gen.get_default_protocol_name()
+    code = fixture_code("siesta.siesta")
+    code.store()
+    calc_engines = {"siesta": {'code': code.uuid, 'options': {"resources": {"num_mpiprocs_per_machine": 1}, "max_wallclock_seconds": 360}}}
+
+    build = inp_gen.get_filled_builder(structure, calc_engines, protocol, relaxation_type="atoms_only")
+
+    assert "parameters" in build
+
+def test_stmworkchain_inpgen(aiida_profile, fixture_code, generate_structure):
+    """Test the validation of subclasses of `InputsGenerator`."""
+
+    #Here I fake the pseudofamilies
+    PsmlFamily.objects.get_or_create("nc-sr-04_pbe_standard_psml")
+    PsmlFamily.objects.get_or_create("nc-sr-04_pbe_stringent_psml")
+
+    from aiida_siesta.workflows.utils.inputs_generators import StmWorkChainInputsGenerator
+
+    inp_gen = StmWorkChainInputsGenerator(WorkflowFactory("siesta.stm"))
+    structure = generate_structure()
+    protocol = inp_gen.get_default_protocol_name()
+    code = fixture_code("siesta.siesta")
+    code.store()
+    code2 = fixture_code("siesta.stm")
+    code2.store()
+    calc_engines = {"siesta": {'code': code.uuid, 'options': {"resources": {"num_mpiprocs_per_machine": 1}, "max_wallclock_seconds": 360}},
+                    "stm": {'code': code2.uuid, 'options': {"resources": {"num_mpiprocs_per_machine": 1}, "max_wallclock_seconds": 360}}
+            }
+
+    build = inp_gen.get_filled_builder(structure, calc_engines, protocol, stm_mode="constant-height", stm_value=2)
 
     assert "parameters" in build


### PR DESCRIPTION
A set of unit-tests for the WorkChains.

With this we reach coverage:
* workflows 76%
* calculations 86%
* parsers 83%
* data 44%
* commands 0%
* groups  100%

Data, commands and groups will change soon (moving to aiida_pseudo plugin). The rest is finally at a decent coverage.