### PR TITLE
Documentation for SiestaIterator and SiestaConverger. Also added entr…

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -14,7 +14,7 @@ Since November 2019, Emanuele Bosoni is in charge of the code's development and 
 under the supervision of Alberto Garcia.
 
 Pol Febrer contributed the SiestaIterator and SiestaConverger workflows, including the underline
-metaclasses system.
+abstract classes system.
 
 We gratefully acknowledge the help and support of the AiiDA team in
 Lausanne.

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,7 +1,6 @@
 The Siesta input plugin was originally developed by Victor M. Garcia-Suarez.
 
-Alberto Garcia further improved the Siesta input plugin and wrote the parser
-for Siesta and the STM plugin.
+Alberto Garcia further improved the Siesta input plugin and wrote the parser for Siesta and the STM plugin.
 
 Emanuele Bosoni contributed the band-structure support for the Siesta plugin.
 
@@ -9,8 +8,13 @@ Vladimir Dikan and Alberto Garcia developed the workflows and
 refined the architecture of the package.
 
 Vladimir Dikan and Emanuele Bosoni ported the plugin and the base workflow to AiiDA 1.0.
-
 Alberto Garcia futher refined the 1.0-compatible functionality.
+
+Since November 2019, Emanuele Bosoni is in charge of the code's development and maintenance,
+under the supervision of Alberto Garcia.
+
+Pol Febrer contributed the SiestaIterator and SiestaConverger workflows, including the underline
+metaclasses system.
 
 We gratefully acknowledge the help and support of the AiiDA team in
 Lausanne.

--- a/aiida_siesta/docs/index.rst
+++ b/aiida_siesta/docs/index.rst
@@ -36,6 +36,9 @@ Alberto Garcia futher refined the 1.0-compatible functionality.
 Since November 2019, Emanuele Bosoni is in charge of the code's development and maintenance, 
 under the supervision of Alberto Garcia.
 
+Pol Febrer contributed the SiestaIterator and SiestaConverger workflows, including the underline
+metaclasses system.
+
 We acknowledge partial support from the Spanish Research Agency (projects
 FIS2012-37549-C05-05, FIS2015-64886-C5-4-P and PGC2018-096955-B-C44) and  by the `MaX 
 European Centre of Excellence <http://www.max-centre.eu/>`_ funded by the Horizon 2020 
@@ -82,6 +85,8 @@ SIESTA Workflows
    workflows/bandgap
    workflows/eos
    workflows/stm
+   workflows/iterator
+   workflows/converger
 ..
    
 

--- a/aiida_siesta/docs/index.rst
+++ b/aiida_siesta/docs/index.rst
@@ -37,7 +37,7 @@ Since November 2019, Emanuele Bosoni is in charge of the code's development and 
 under the supervision of Alberto Garcia.
 
 Pol Febrer contributed the SiestaIterator and SiestaConverger workflows, including the underline
-metaclasses system.
+abstract classes system.
 
 We acknowledge partial support from the Spanish Research Agency (projects
 FIS2012-37549-C05-05, FIS2015-64886-C5-4-P and PGC2018-096955-B-C44) and  by the `MaX 

--- a/aiida_siesta/docs/plugins/siesta.rst
+++ b/aiida_siesta/docs/plugins/siesta.rst
@@ -266,7 +266,7 @@ aiida_siesta/examples/plugins/siesta.
      determine canonical unit cells and k-point information in an easy
      way. For more general information, refer to the `SeeK-path documentation`_.
 
-  .. warning:: as explained in the `aiida documentation`_, "SeeK-path"
+  .. warning:: "SeeK-path"
      might modify the structure to follow particular conventions
      and the generated kpoints might only 
      apply on the internally generated 'primitive_structure' and not 
@@ -563,6 +563,5 @@ those files as a list as follows::
 See for example example_ldos.py in aiida_siesta/examples/plugins/siesta.
 
 .. _SeeK-path documentation: https://seekpath.readthedocs.io/en/latest/
-.. _aiida guidelines: https://aiida-core.readthedocs.io/en/latest/get_started/computers.html
+.. _aiida guidelines: https://aiida.readthedocs.io/projects/aiida-core/en/latest/howto/run_codes.html
 .. _HPKOT paper: http://dx.doi.org/10.1016/j.commatsci.2016.10.015
-.. _aiida documentation: https://aiida.readthedocs.io/projects/aiida-core/en/latest/apidoc/aiida.tools.html#aiida.tools.get_explicit_kpoints_path

--- a/aiida_siesta/docs/workflows/converger.rst
+++ b/aiida_siesta/docs/workflows/converger.rst
@@ -4,7 +4,7 @@ SIESTA Converger workflow
 Description
 -----------
 
-The **SiestaConvereger** is a tool to facilitate convergence tests with Siesta.
+The **SiestaConverger** is a tool to facilitate convergence tests with Siesta.
 It extends the **SiestaIterator** to accept a target quantity that is checked
 after each step to evaluate whether convergence has been reached or not.
 The convergence check just consists in calculating the difference in the target quantity 
@@ -66,8 +66,8 @@ The following outputs are returned:
 
 * **converged_target_value** :py:class:`Float <aiida.orm.Float>`
 
-  The value of the target when the convergence has been reached, or in the last step of
-  the iteration.
+  The value of the target when the convergence has been reached. Returned only if
+  the convergence is succesfull.
 
 .. |br| raw:: html
 

--- a/aiida_siesta/docs/workflows/converger.rst
+++ b/aiida_siesta/docs/workflows/converger.rst
@@ -1,0 +1,92 @@
+SIESTA Converger workflow
++++++++++++++++++++++++++++++++++
+
+Description
+-----------
+
+The **SiestaConvereger** is a tool to facilitate convergence tests with Siesta.
+It extends the **SiestaIterator** to accept a target quantity that is checked
+after each step to evaluate whether convergence has been reached or not.
+The convergence check just consists in calculating the difference in the target quantity 
+between the present step and the step before and comparing it with a threshold value
+passed by the user in input.
+An example on the use of the **SiestaConverger** is
+/aiida_siesta/examples/workflows/example_convergence.py.
+
+
+Supported Siesta versions
+-------------------------
+
+At least 4.0.1 of the 4.0 series, and 4.1-b3 of the 4.1 series, which
+can be found in the development platform
+(https://gitlab.com/siesta-project/siesta).
+
+Inputs
+------
+
+All the **SiestaIterator** inputs are as well inputs of the **SiestaConvereger**,
+they are described in the corresponding
+:ref:`documentation <siesta-iterator-inputs>`.
+Additional inputs are:
+
+* **target**, class :py:class:`Str  <aiida.orm.Str>`, *Optional*
+
+  The parameter the user wants to track in order to check if convergence has been reached.
+  All the quantities returned in the `output_parameters` dictionary of the **SiestaBaseWorkChain**
+  are accepted for this scope, excluding keys that don't have a `float` or `int` as a value.
+  Typical values are the Kohn-Sham
+  (`E_KS`), Free (`FreeE`), Band (`Ebs`), and Fermi (`E_Fermi`)
+  energies, and the total spin (`stot`); however the user might also think to converge
+  calculations-time related quantities.
+
+  The `E_KS` is the default value.
+
+
+.. |br| raw:: html
+
+    <br />
+
+* **threshold**, class :py:class:`Float <aiida.orm.Float>`, *Optional*
+
+  The maximum difference between two consecutive steps to consider that convergence is reached.
+  Default is `Float(0.01)`.
+
+Outputs
+-------
+
+The following outputs are returned:
+
+* **converged** :py:class:`Bool <aiida.orm.Bool>`
+
+  Returning `True` or `False`, whether the target has converged or not.
+
+.. |br| raw:: html
+
+    <br />
+
+* **converged_target_value** :py:class:`Float <aiida.orm.Float>`
+
+  The value of the target when the convergence has been reached, or in the last step of
+  the iteration.
+
+.. |br| raw:: html
+
+    <br />
+
+* **converged_parameters** :py:class:`Dict <aiida.orm.Dict>`
+
+  The values for the parameters that was enough to achieve convergence.
+  If converged is not achieved, it won't be returned.
+
+Protocol system
+---------------
+
+The protocol system is not directly available for this WorkChain.
+However inputs of the **SiestaBaseWorkChain** can be obtained in a dictionary in this way::
+
+        inp_gen = SiestaBaseWorkChain.inputs_generator()
+        inputs = inp_gen.get_inputs_dict(structure, calc_engines, protocols)
+
+The inputs of `get_inputs_dict` are explained in the :ref:`protocols documentation <how-to>`.
+Then the user must define at least the input **iterate_over** in order to be able to submit
+the **SiestaConverger** WorkChain (if no **target** is specified, the `E_KS` is used).

--- a/aiida_siesta/docs/workflows/iterator.rst
+++ b/aiida_siesta/docs/workflows/iterator.rst
@@ -1,0 +1,118 @@
+SIESTA Iterator workflow
++++++++++++++++++++++++++++++++++
+
+Description
+-----------
+
+The **SiestaIterator** is a tool to facilitate the submission of several Siesta Calcultions
+in an authomatic way. It allows the iteration over Siesta parameters
+and, more in genearal, over inputs of a **SiestaBaseWorkChain**.
+An example on the use of the **SiestaConverger** is
+/aiida_siesta/examples/workflows/example_iterate.py.
+
+
+Supported Siesta versions
+-------------------------
+
+At least 4.0.1 of the 4.0 series, and 4.1-b3 of the 4.1 series, which
+can be found in the development platform
+(https://gitlab.com/siesta-project/siesta).
+
+.. _siesta-iterator-inputs:
+
+Inputs
+------
+
+All the **SiestaBaseWorkChain** inputs are as well inputs of the **SiestaIterator**,
+therefore the system and DFT specifications (structure, parameters, etc.) are
+inputted in the WorkChain using the same syntax explained in the **SiestaBaseWorkChain**
+:ref:`documentation <siesta-base-wc-inputs>`.
+The additional inputs are:
+
+* **iterate_over**, class :py:class:`Dict  <aiida.orm.Dict>`, *Mandatory*
+
+  A dictionary where each key is the name of a parameter we want to iterate
+  over (`str`) and each value is a `list` with all the values to iterate over for
+  the corresponding key.  
+  Accepted keys are:
+
+  * Name of the input ports of the **SiestaBaseWorkChain**. Meaning all the names listed
+    :ref:`here <siesta-base-wc-inputs>`.
+    In this case, the corresponding values list must contains the list of `DataType` nodes
+    (stored or unstored) accepted by the key. Examples are::
+
+        code1 = load_code("SiestaHere@localhost")
+        code2 = load_code("SiestaThere@remotemachine")
+        iterate_over = {"code" : [code1,code2]}
+
+        struct1 = StructureData(ase=ase_struct_1)
+        struct2 = StructureData(ase=ase_struct_2)
+        iterate_over = {"structure" : [struct1,struct2]}
+
+  * Name of accepted Siesta input keywords (for instance `mesh-cutoff`, `pao-energy-shift`, etc ...).
+    In this case, the corresponding values list must contains the list of values directly, meaning
+    `str`, `float`, `int` or `bool` python types. Examples are::
+
+        iterate_over = {"spin" : ["polarized", "spin-orbit"]}
+
+    .. warning:: In order to guarantee full flexibility, no check on the Siesta parameters
+    is performed. If you pass as key something not recognized by Siesta,
+    the SiestaIterator will include it in the `parameters` input and run the calculation with
+    no warning issued. Because Siesta will not understand the keyword, it will ignore it,
+    resulting in a series of identical calculations.
+    
+  The `iterate_over` is a dictionary because it is possible to iterate over several keywords at
+  the same time. Something of this kind::
+
+        struct1 = StructureData(ase=ase_struct_1)
+        struct2 = StructureData(ase=ase_struct_2)
+        iterate_over = {"structure" : [struct1,struct2], "spin" : ["polarized", "spin-orbit"]}
+
+  is perfectly acceptable and the way the algorithm handle with these multiple iterations is decided
+  by the **SiestaIterator** input explained next in this list.
+
+.. |br| raw:: html
+
+    <br />
+
+* **iterate_mode**, class :py:class:`Str <aiida.orm.Str>`, *Optional*
+
+  Indicates the way the parameters should be iterated. Currently allowed values are
+  'zip' (zips all the parameters together, this imposes that all keys should
+  have the same number of values in the list!) and 'product' (performs a cartesian product of the 
+  parameters, meaning that all possible combinations of parameters and values are explored).
+
+  The option 'zip' is the default one.
+
+.. |br| raw:: html
+
+    <br />
+
+* **batch_size**, class :py:class:`Int <aiida.orm.Int>`, *Optional*
+
+  The maximum number of simulations that should run at the same time.
+  You can set this to a very large number if you want that all simulations run in
+  one single batch. As default, only one single calculation at the time is submitted.
+
+
+Outputs
+-------
+
+This WorkChain does not generate any output! It is in fact a tool to help the
+submission of multiple calculations and keep them all connected and easy accessible
+through the main workchain node, but it doesn't have any precise scope.
+AiiDA provides a powerful querying system to explore all the results of the submitted calculations.
+
+
+Protocol system
+---------------
+
+The protocol system is not directly available for this WorkChain.
+However inputs of the **SiestaBaseWorkChain** can be obtained in a dictionary in this way::
+
+        inp_gen = SiestaBaseWorkChain.inputs_generator()
+        inputs = inp_gen.get_inputs_dict(structure, calc_engines, protocols)
+
+The inputs of `get_inputs_dict` are explained in the :ref:`protocols documentation <how-to>`.
+Then the user must define at least the input **iterate_over** in order to be able to submit
+the **SiestaIterator** WorkChain.

--- a/aiida_siesta/docs/workflows/iterator.rst
+++ b/aiida_siesta/docs/workflows/iterator.rst
@@ -4,9 +4,9 @@ SIESTA Iterator workflow
 Description
 -----------
 
-The **SiestaIterator** is a tool to facilitate the submission of several Siesta Calcultions
-in an authomatic way. It allows the iteration over Siesta parameters
-and, more in genearal, over inputs of a **SiestaBaseWorkChain**.
+The **SiestaIterator** is a tool to facilitate the submission of several Siesta Calculations
+in an automatic way. It allows the iteration over Siesta parameters
+and, more in general, over inputs of a **SiestaBaseWorkChain**.
 An example on the use of the **SiestaConverger** is
 /aiida_siesta/examples/workflows/example_iterate.py.
 

--- a/aiida_siesta/examples/workflows/example_iterate.py
+++ b/aiida_siesta/examples/workflows/example_iterate.py
@@ -43,7 +43,7 @@ try:
     ase_struct = sisl.geom.diamond(5.430, 'Si').toASE()
 except:
     # Or using ASE
-    import ase
+    import ase.build
 
     ase_struct = ase.build.bulk('Si', 'diamond', 5.430)
 # Then just pass it to StructureData, which is the type that Aiida works with
@@ -131,20 +131,20 @@ inputs = {
 # simulations iterating over parameters
 
 # Iterate over meshcutoff
-process = submit(SiestaIterator, **inputs,
-    iterate_over={
-        'meshcutoff': [100,200,300,400,500,600,700,800,900],
-    },
-    batch_size=Int(4)
-)
+#process = submit(SiestaIterator, **inputs,
+#    iterate_over={
+#        'meshcutoff': [100,200,300,400,500,600,700,800,900],
+#    },
+#    batch_size=Int(4)
+#)
 
 # Iterate over meshcutoff and energyshift at the same time 
-process = submit(SiestaIterator, **inputs,
-    iterate_over={
-        'meshcutoff': [100,200,300],
-        'pao-energyshift': [0.02, 0.01, 0.05]
-    },
-)
+#process = submit(SiestaIterator, **inputs,
+#    iterate_over={
+#        'meshcutoff': [100,200,300],
+#        'pao-energyshift': [0.02, 0.01, 0.05]
+#    },
+#)
 
 # This will run three simulations with these values (meshcutoff, energyshift)
 # (100, 0.02), (200, 0.01), (300, 0.05)

--- a/aiida_siesta/workflows/converge.py
+++ b/aiida_siesta/workflows/converge.py
@@ -77,7 +77,7 @@ class BaseConvergencePlugin:
             help="The values for the parameters that was enough to achieve convergence. "
             "If converged is not achieved, it won't be returned",
         )
-        spec.output('converged_target_value', help="The value of the target with convergence reached.")
+        spec.output('converged_target_value', required=False, help="The value of the target with convergence reached.")
 
     def initialize(self):
         """

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -148,7 +148,6 @@ class BaseIteratorWorkChain(WorkChain, ABC):
             "iterate_over",
             valid_type=DataFactory('dict'),
             serializer=cls._iterate_input_serializer,
-            required=False,
             help='''A dictionary where each key is the name of a parameter we want to iterate
             over (str) and each value is a list with all the values to iterate over for
             that parameter. Each value in the list can be either a node (unstored or stored)

--- a/setup.json
+++ b/setup.json
@@ -46,7 +46,9 @@
             "siesta.base = aiida_siesta.workflows.base:SiestaBaseWorkChain",
 	    "siesta.eos = aiida_siesta.workflows.eos:EqOfStateFixedCellShape",
 	    "siesta.bandgap = aiida_siesta.workflows.bandgap:BandgapWorkChain",
-            "siesta.stm = aiida_siesta.workflows.stm:SiestaSTMWorkChain"
+            "siesta.stm = aiida_siesta.workflows.stm:SiestaSTMWorkChain",
+	    "siesta.iterator = aiida_siesta.workflows.iterate:SiestaIterator",
+	    "siesta.converger = aiida_siesta.workflows.converge:SiestaConverger"
         ],
         "aiida.data": [
             "siesta.psf = aiida_siesta.data.psf:PsfData",


### PR DESCRIPTION
Documentation of `SiestaConverger` and `SiestaIterator`. Also added entry points.

Missing the SiestaSequentialConverger.
Also the examples have been modified to the better cover the scope of explaining the two main new WorkChains.
Also included Pol as author.