### PR TITLE
Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6','3.8']
+        python-version: ['3.6','3.7.7','3.8']
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Cache python dependencies
       id: cache-pip
@@ -53,7 +53,7 @@ jobs:
         restore-keys: |
           pip-${{ matrix.python-version }}-tests
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,20 @@ jobs:
       matrix:
         python-version: ['3.6','3.7.7','3.8']
 
+    services:
+        postgres:
+            image: postgres:10
+            env:
+                POSTGRES_DB: test_${{ matrix.backend }}
+                POSTGRES_PASSWORD: ''
+                POSTGRES_HOST_AUTH_METHOD: trust
+            ports:
+            -    5432:5432
+        rabbitmq:
+            image: rabbitmq:latest
+            ports:
+            -   5672:5672
+
     steps:
     - uses: actions/checkout@v2
 
@@ -52,6 +66,7 @@ jobs:
         key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
         restore-keys: |
           pip-${{ matrix.python-version }}-tests
+    
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -59,13 +74,8 @@ jobs:
 
     - name: Install system dependencies
       run: |
-        wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | sudo apt-key add -
-        echo 'deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
-        echo 'deb https://dl.bintray.com/rabbitmq/debian bionic main' | sudo tee -a /etc/apt/sources.list.d/bintray.rabbitmq.list
         sudo apt update
-        sudo apt install postgresql postgresql-server-dev-all postgresql-client
-        sudo apt install rabbitmq-server
-        sudo systemctl status rabbitmq-server.service
+        sudo apt install postgresql-10
     - name: Install python dependencies
       run: |
         pip install -e .[dev]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
         restore-keys: |
           pip-${{ matrix.python-version }}-tests
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6','3.7','3.8']
+        python-version: ['3.6','3.8']
 
     steps:
     - uses: actions/checkout@v1

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c), 2015-2017, Alberto Garcia, Victor M. Garcia-Suarez, Emanuele
-Bosoni, Vladimir Dikan
+Bosoni, Vladimir Dikan, Pol Febrer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Since 08/07/2020, github actions moved from python 3.7.7 to python 3.7.8  (released the 26/07/2020). Unfortunately this lead to an issue with PYYAML, as described here:
https://github.com/actions/setup-python/issues/107
The solution is to pin 3.7.7 for the tests. It is possible only with version v2 of action/setup-python.

Take the occasion to change the handle of rabbitmq and postgresql in the actions.