### PR TITLE
Simply made BaseConverger subclass of InputIterator.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -64,8 +64,7 @@ disable=bad-continuation,
         inconsistent-return-statements,
         import-outside-toplevel,
 	missing-docstring,
-	protected-access,
-	no-member
+	protected-access
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/aiida_siesta/workflows/converge.py
+++ b/aiida_siesta/workflows/converge.py
@@ -29,7 +29,7 @@ def generate_convergence_results(iteration_keys, variable_values, target_values,
     return convergence_results
 
 
-class BaseConvergencePlugin:
+class BaseConvergencePlugin(InputIterator):
     '''
     Plugin to add to an Iterator workchain to convert it to a convergence workflow.
 

--- a/aiida_siesta/workflows/eos.py
+++ b/aiida_siesta/workflows/eos.py
@@ -216,7 +216,7 @@ class EqOfStateFixedCellShape(WorkChain):
             help="Volume per atom around which to perform the EqOfState"
         )
         spec.expose_inputs(SiestaBaseWorkChain, exclude=('metadata',))
-        spec.inputs._ports['pseudos'].dynamic = True  #Temporary fix to issue #135 plumpy
+        #spec.inputs._ports['pseudos'].dynamic = True  #Temporary fix to issue #135 plumpy
         spec.outline(cls.initio, cls.run_base_wcs, cls.return_results)
         spec.output(
             'results_dict',

--- a/aiida_siesta/workflows/iterate.py
+++ b/aiida_siesta/workflows/iterate.py
@@ -814,10 +814,3 @@ class SiestaIterator(InputIterator):
     _process_class = SiestaBaseWorkChain
     _params_lookup = SIESTA_ITERATION_PARAMS
     _expose_inputs_kwargs = {'exclude': ('metadata',)}
-
-    @classmethod
-    def define(cls, spec):
-        super().define(spec)
-
-        spec.inputs._ports['pseudos'].dynamic = True
-        # spec.input('units', valid_type=Str, required=False, help='The units of the parameter')

--- a/aiida_siesta/workflows/stm.py
+++ b/aiida_siesta/workflows/stm.py
@@ -51,7 +51,7 @@ class SiestaSTMWorkChain(WorkChain):
         super(SiestaSTMWorkChain, cls).define(spec)
         spec.expose_inputs(SiestaBaseWorkChain, exclude=('metadata',))
         #Temporary fix to issue #135 plumpy
-        spec.inputs._ports['pseudos'].dynamic = True  #pylint: disable=protected-access
+        #spec.inputs._ports['pseudos'].dynamic = True  #pylint: disable=protected-access
         spec.input('emin', valid_type=Float, help='Lower boundary energy (in eV respect to Ef) for LDOS calculation')
         spec.input('emax', valid_type=Float, help='Higher boundary energy (in eV respect to Ef) for LDOS calculation')
         spec.input('stm_code', valid_type=Code, help='STM plstm code')

--- a/setup.json
+++ b/setup.json
@@ -15,7 +15,7 @@
 	"Development Status :: 4 - Beta"
     ],
     "install_requires": [
-	"aiida_core[atomic_tools]>=1.2.1,<2.0.0"
+	"aiida_core[atomic_tools]>=1.3.0,<2.0.0"
     ],
     "extras_require": {
 	"dev": [


### PR DESCRIPTION
It make sense to have BaseConverger as a subclass of InputIterator. In fact a converger is an iterator. This prevents no-member error of pylint.
Moreover I updated the aiida-core dependence to 1.3.0. Here the issue #135 of plumpy is fixed and therefore we can get rid of the workaround for this issue.