### PR TITLE
Unpin py3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Cache python dependencies
       id: cache-pip
@@ -21,7 +21,7 @@ jobs:
               pip-pre-commit-
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
           python-version: 3.8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6','3.7.7','3.8']
+        python-version: ['3.6','3.7','3.8']
 
     services:
         postgres:


### PR DESCRIPTION
The virtual environment of runners on Github Actions had an issue, where installing a different pyyaml version than the one present resulted in an error.
The issue has been resolved in the latest image, and so the workaround of specifically requesting the (outdated) Python version 3.7.7 can be dropped.
Took the occasion to update also the version of runners for all the jobs in the actions.