### PR TITLE
Fix requirement of exposed ports.

### DIFF
--- a/aiida_siesta/workflows/utils/iterate_absclass.py
+++ b/aiida_siesta/workflows/utils/iterate_absclass.py
@@ -365,12 +365,14 @@ class BaseIterator(WorkChain):
         # them you might not pass them directly) and save them in a variable.
         if "namespace" in cls._expose_inputs_kwargs:
             cls._exposed_input_keys = spec._exposed_inputs[cls._expose_inputs_kwargs["namespace"]][cls._process_class]
-            for input_key in cls._exposed_input_keys:
-                spec.inputs._ports[cls._expose_inputs_kwargs["namespace"]][input_key].required = False
+            if cls._iterate_over_port:
+                for input_key in cls._exposed_input_keys:
+                    spec.inputs._ports[cls._expose_inputs_kwargs["namespace"]][input_key].required = False
         else:
             cls._exposed_input_keys = spec._exposed_inputs[None][cls._process_class]
-            for input_key in cls._exposed_input_keys:
-                spec.inputs._ports[input_key].required = False
+            if cls._iterate_over_port:
+                for input_key in cls._exposed_input_keys:
+                    spec.inputs._ports[input_key].required = False
 
     def initialize(self):
         """


### PR DESCRIPTION
The feature to impose the exposed input ports to be "not-required" was due to the
fact that users can now iterate over this ports name, defining them
in the `iterate_over` dictionary.
However, when the `iterate_over` port is not accepted (new feature implemented
recently), it has no sense to impose that the exposed inputs are not-required.
This commit fixes the problem.
@pfebrer96 Do you agree??