### PR TITLE
Change atomic tools

### DIFF
--- a/aiida_siesta/examples/plugins/00_README
+++ b/aiida_siesta/examples/plugins/00_README
@@ -2,7 +2,7 @@ This folder contains examples devoted to explain how to perform several tasks ma
 distributed in aiida_siesta.
 These examples should be consider templates that users should modify according to their will in order
 to perform specific tasks on their own particular system.
-All the example can be run with the following syntax:
+All the examples can be run with the following syntax:
 	runaiida example_name.py {--send, --dont-send} {options}
 The choice "--send" submits the example to the daemon. The choice "--dont-send" creates a test folder
 in /submit_test, but it does not actually run the calculation.

--- a/aiida_siesta/examples/plugins/siesta/example_bands.py
+++ b/aiida_siesta/examples/plugins/siesta/example_bands.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
 import os.path as op
 import sys
 

--- a/aiida_siesta/examples/plugins/siesta/example_cif_bands.py
+++ b/aiida_siesta/examples/plugins/siesta/example_cif_bands.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import pymatgen as mg
 import ase.io
@@ -62,13 +59,11 @@ options = {
 #---------------------------------------------------------------------
 
 # Structure -----------------------------------------
-# Two choices for importing the .cif, pymatgen or ase. Then
+# For importing the .cif we use ase. Then
 # passing through SeeK-path  to get the standardized cell.
 # Necessary for the automatic choice of the bands path.
-structure = mg.Structure.from_file("data/O2_ICSD_173933.cif", primitive=False)
-s = StructureData(pymatgen_structure=structure)
-#structure =ase.io.read("data/O2_ICSD_173933.cif")
-#s = StructureData(ase=structure)
+structure =ase.io.read("data/O2_ICSD_173933.cif")
+s = StructureData(ase=structure)
 
 seekpath_parameters = {'reference_distance': 0.02, 'symprec': 0.0001}
 result = get_explicit_kpoints_path(s, **seekpath_parameters)

--- a/aiida_siesta/examples/plugins/siesta/example_first.py
+++ b/aiida_siesta/examples/plugins/siesta/example_first.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 
 #Not required by AiiDA
-from __future__ import absolute_import
-from __future__ import print_function
 import os.path as op
 import sys
 

--- a/aiida_siesta/examples/plugins/siesta/example_geom_fail.py
+++ b/aiida_siesta/examples/plugins/siesta/example_geom_fail.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import print_function
-
 import sys
 
 from aiida.engine import submit

--- a/aiida_siesta/examples/plugins/siesta/example_ldos.py
+++ b/aiida_siesta/examples/plugins/siesta/example_ldos.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import print_function
 
 import sys
 import os

--- a/aiida_siesta/examples/plugins/siesta/example_magnetic_bands.py
+++ b/aiida_siesta/examples/plugins/siesta/example_magnetic_bands.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import os
 

--- a/aiida_siesta/examples/plugins/siesta/example_molecule.py
+++ b/aiida_siesta/examples/plugins/siesta/example_molecule.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import os
 

--- a/aiida_siesta/examples/plugins/siesta/example_psf_family.py
+++ b/aiida_siesta/examples/plugins/siesta/example_psf_family.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import print_function
 
 import sys
 

--- a/aiida_siesta/examples/plugins/siesta/example_psml.py
+++ b/aiida_siesta/examples/plugins/siesta/example_psml.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import print_function
 
 import sys
 import os.path as op
@@ -38,7 +34,7 @@ except IndexError:
 try:
     codename = sys.argv[2]
 except IndexError:
-    codename = 'Siesta4.0.1@kelvin'
+    codename = 'SiestaMax@kelvin'
 
 #
 #------------------Code and computer options ---------------------------

--- a/aiida_siesta/examples/plugins/siesta/example_relax.py
+++ b/aiida_siesta/examples/plugins/siesta/example_relax.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import print_function
 import os.path as op
 import sys
 

--- a/aiida_siesta/examples/plugins/siesta/example_restart.py
+++ b/aiida_siesta/examples/plugins/siesta/example_restart.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
 
 import os.path as op
 import sys

--- a/aiida_siesta/examples/plugins/siesta/example_scf_fail.py
+++ b/aiida_siesta/examples/plugins/siesta/example_scf_fail.py
@@ -1,10 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import print_function
-
-#
 # This is an example of a calculation that will end in a FINISHED
 # state but with a non-zero exit code, due to lack of scf convergence
 # in the allotted number of iterations.

--- a/aiida_siesta/examples/plugins/siesta/example_soc_bands.py
+++ b/aiida_siesta/examples/plugins/siesta/example_soc_bands.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
 
 import os.path as op
 import sys

--- a/aiida_siesta/examples/plugins/siesta/example_varcell.py
+++ b/aiida_siesta/examples/plugins/siesta/example_varcell.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import print_function
 import os.path as op
 import sys
 

--- a/aiida_siesta/examples/plugins/stm/example_current.py
+++ b/aiida_siesta/examples/plugins/stm/example_current.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 #
 # Test for STM plugin
 #
@@ -17,9 +16,6 @@
 #  The height argument is optional. It is the height (in the z coordinate of
 #  the LDOS box) at which the "image" is going to be computed.
 #
-
-from __future__ import absolute_import
-from __future__ import print_function
 
 import sys
 

--- a/aiida_siesta/examples/plugins/stm/example_height.py
+++ b/aiida_siesta/examples/plugins/stm/example_height.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
 #
 # Test for STM plugin
 #
@@ -17,9 +16,6 @@
 #  The height argument is optional. It is the height (in the z coordinate of
 #  the LDOS box) at which the "image" is going to be computed.
 #
-
-from __future__ import absolute_import
-from __future__ import print_function
 
 import sys
 

--- a/aiida_siesta/examples/uploadfamily.py
+++ b/aiida_siesta/examples/uploadfamily.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env runaiida
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import sys
-#from aiida import load_dbenv
-#load_dbenv()
 import aiida_siesta.data.psf as psf
 from aiida.cmdline.utils import decorators
 
@@ -22,7 +17,7 @@ def uploadfamily(*args):
 
     if not len(args) == 3 and not len(args) == 4:
         print(("Usage:"), file=sys.stderr)
-        print(("./uploadfamily.py FOLDER_NAME <group_name>  <group_description> "
+        print(("runaiida uploadfamily.py FOLDER_NAME <group_name>  <group_description> "
                               "[OPTIONAL: --stop-if-existing]\n"), file=sys.stderr)
         sys.exit(1)
 

--- a/aiida_siesta/examples/workflows/example_eos.py
+++ b/aiida_siesta/examples/workflows/example_eos.py
@@ -7,11 +7,11 @@ import sys
 #AiiDA classes and functions
 from aiida.engine import submit
 from aiida.orm import load_code
-from aiida.orm import (Float, Dict, StructureData, KpointsData)
+from aiida.orm import (Int, Float, Dict, StructureData, KpointsData)
 from aiida_siesta.data.psf import PsfData
 from aiida_siesta.workflows.eos import EqOfStateFixedCellShape
 
-# This example shows the use of the IsotropicEosFast
+# This example shows the use of the EqOfStateFixedCellShape
 # Requires a working aiida profile and the set up of
 # a code (it submits the WorkChain to the daemon).
 # To run it: runaiida example_eos.py codename
@@ -120,7 +120,8 @@ inputs = {
     'kpoints': kpoints,
     'pseudos': pseudos_dict,
     'options': options,
-    'volume_per_atom': Float(19)
+    'volume_per_atom': Float(19),
+    'batch_size': Int(7) #selects the number of volumes to run at the same time
 }
 
 process = submit(EqOfStateFixedCellShape, **inputs)

--- a/aiida_siesta/examples/workflows/example_iterate.py
+++ b/aiida_siesta/examples/workflows/example_iterate.py
@@ -157,10 +157,10 @@ process = submit(SiestaIterator, **inputs,
         'pao-energyshift': [0.02, 0.01, 0.05]
     },
     iterate_mode=Str('product'),
-    batch_size=Int(3)
+    batch_size=Int(3) #This selects how many values run at the same time
 )
 # This will run nine simulations with these values (meshcutoff, energyshift)
-# (100, 0.02), (100, 0.01), (300, 0.05), (100, 0.02), (100, 0.01) ...
+# (100, 0.02), (100, 0.01), (300, 0.05), (200, 0.02), (200, 0.01) ...
 
 # Print some info
 print("Submitted workchain; ID={}".format(process.pk))

--- a/aiida_siesta/examples/workflows/example_protocols.py
+++ b/aiida_siesta/examples/workflows/example_protocols.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env runaiida
 """
 File showcasing the submission of a SiestaBaseWorkChain using the protocol system.
 """

--- a/aiida_siesta/examples/workflows/example_protocols_stm.py
+++ b/aiida_siesta/examples/workflows/example_protocols_stm.py
@@ -1,10 +1,11 @@
+#!/usr/bin/env runaiida
 """
 File showcasing the submission of a SiestaBaseWorkChain using the protocol system.
 """
 import sys
 from aiida_siesta.workflows.stm import SiestaSTMWorkChain
 from aiida.engine import submit
-from aiida.orm import Dict, StructureData
+from aiida.orm import Dict, StructureData, Float
 
 try:
     codename = sys.argv[1]
@@ -15,9 +16,6 @@ try:
 except IndexError:
     stmcodename = 'STMhere@localhost'
 
-
-#Three are the mandatory inputs: structure, a dictionary with the comp resources
-#(calc_engines) and the protocol name
 
 
 # Structure -----------------------------------------
@@ -86,10 +84,8 @@ print(inp_gen.how_to_pass_computation_options())
 
 # As we get the builder and not stored nodes, before submission any user has complete
 # freedom to change something before submission.
-# If no change is performed, just submitting the builder should still work and produce sensible results.
-new_params = builder.parameters.get_dict()
-new_params['max_scf_iterations'] = 200
-builder.parameters = Dict(dict=new_params)
+# For instance the energy range for the construction of the LDOS.
+builder.emin = Float(-6.4) #eV respect to Fermi energy
 
 # Here we just submit the builder
 process = submit(builder)

--- a/aiida_siesta/examples/workflows/example_stm_magn.py
+++ b/aiida_siesta/examples/workflows/example_stm_magn.py
@@ -1,16 +1,18 @@
+#!/usr/bin/env runaiida
+
 import sys
 import os
+import numpy as np
 from aiida.engine import submit
 from aiida.orm import load_code
 from aiida_siesta.calculations.siesta import SiestaCalculation
 from aiida.plugins import DataFactory
 from aiida_siesta.workflows.stm import SiestaSTMWorkChain
 
-# This is an example for the submission of the STM WorkChain.
-# It shows how to select all the inputs of the WorkChain
-# and how to submit it.
+# This is an example for the submission of the STM WorkChain
+# in order to obtain spin dependent stm images
 # For a quick run, type:
-# "runaiida example_stm.py SiestaCode@cmp StmCoode@cmp"
+# "runaiida example_stm_magn.py SiestaCode@cmp StmCoode@cmp"
 # but, as any other example here, it is made to make the user
 # play with all the inputs of the WorkChain
 
@@ -47,19 +49,23 @@ options = {
     }
 }
 #
-# Structure -----------------------------------------
+# Structure, a Cr slab
 #
-from pymatgen import Lattice, Structure, Molecule
+struct_params = {'numbers': np.array([24, 24, 24]),
+ 'positions': np.array([[ 7.800000e-05, -4.700000e-05, -2.434600e-02],
+        [ 1.630000e-04,  3.335886e+00,  7.413000e-02],
+        [ 2.889124e+00,  1.667948e+00, -4.978400e-02]]),
+ 'masses': np.array([51.9961, 51.9961, 51.9961]),
+ 'cell': np.array([[ 5.77810000e+00,  0.00000000e+00,  3.53806584e-16],
+        [-2.88905000e+00,  5.00398139e+00,  3.53806584e-16],
+        [ 0.00000000e+00,  0.00000000e+00,  2.17943981e+01]]),
+ 'pbc': np.array([ True,  True,  True])}
 
-lattice = Lattice.from_parameters(a=5.77810, b=5.77810, c=5.77810*3.771897, alpha=90, beta=90, gamma=120)
+import ase.atoms
 
-coords = [[0.000078, -0.000047, -0.024346],
-          [0.000163, 3.335886, 0.074130],
-          [2.889124, 1.667948, -0.049784]]
+truct = ase.atoms.Atoms().fromdict(struct_params)
 
-truct = Structure(lattice, ["Cr", "Cr", "Cr"], coords, coords_are_cartesian=True)
-
-s = StructureData(pymatgen_structure=truct)
+s = StructureData(ase=truct)
 #
 # Parameters ---------------------------------------------------
 #

--- a/aiida_siesta/workflows/eos.py
+++ b/aiida_siesta/workflows/eos.py
@@ -98,19 +98,20 @@ def rescale(structure, scale):
 def scale_to_vol(structure, vol):
     """
     Calcfunction to scale a structure to a target volume.
-    Uses pymatgen.
+    Uses ase.
     :param stru: An aiida structure
     :param vol: The target volume per atom in angstroms
     :return: The new scaled AiiDA structure
     """
 
-    in_structure = structure.get_pymatgen_structure()
+    in_structure = structure.get_ase()
     new = in_structure.copy()
-    new.scale_lattice(float(vol) * in_structure.num_sites)
+    vol_ratio = vol * len(in_structure) / in_structure.get_volume()
+    new.set_cell(in_structure.get_cell() * pow(vol_ratio, 1 / 3), scale_atoms=True)
     StructureData = DataFactory("structure")
-    structure = StructureData(pymatgen_structure=new)
+    structure_new = StructureData(ase=new)
 
-    return structure
+    return structure_new
 
 
 def get_scaled(val, inputs):

--- a/setup.json
+++ b/setup.json
@@ -15,7 +15,9 @@
 	"Development Status :: 4 - Beta"
     ],
     "install_requires": [
-	"aiida_core[atomic_tools]>=1.3.0,<2.0.0"
+	"aiida_core>=1.3.0,<2.0.0",
+	"ase~=3.18",
+	"seekpath~=1.9,>=1.9.3"
     ],
     "extras_require": {
 	"dev": [


### PR DESCRIPTION
Choice to not have both pymatgen and ase as dependences. Decided to go with ase because it has less dependeces. Therefore now drop the dependence on "atomic-tools" of aiida (containing both pyamatgen and ase) and introduced direct dependence on ase and seekpath.
This required to remove every call to pymatgen in the package. Substitute with a call to ase doing the same job.