### PR TITLE
Fix bands path

### DIFF
--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -29,17 +29,17 @@ class SiestaCalculation(CalcJob):
     ###################################################################
 
     # Parameters stored as class variables
-    # 1) Keywords that cannot be set (need to canonoze this?)
+    # 1) Keywords that cannot be set (already canonized by FDFDict)
     # 2) Filepaths of certain outputs
-    _aiida_blocked_keywords = ['system-name', 'system-label']
-    _aiida_blocked_keywords.append('number-of-species')
-    _aiida_blocked_keywords.append('number-of-atoms')
-    _aiida_blocked_keywords.append('lattice-constant')
-    _aiida_blocked_keywords.append('atomic-coordinates-format')
-    _aiida_blocked_keywords.append('use-tree-timer')
-    _aiida_blocked_keywords.append('xml-write')
-    _aiida_blocked_keywords.append('dm-use-save-dm')
-    _aiida_blocked_keywords.append('geometry-must-converge')
+    _aiida_blocked_keywords = [FDFDict.translate_key('system-name'), FDFDict.translate_key('system-label')]
+    _aiida_blocked_keywords.append(FDFDict.translate_key('number-of-species'))
+    _aiida_blocked_keywords.append(FDFDict.translate_key('number-of-atoms'))
+    _aiida_blocked_keywords.append(FDFDict.translate_key('lattice-constant'))
+    _aiida_blocked_keywords.append(FDFDict.translate_key('atomic-coordinates-format'))
+    _aiida_blocked_keywords.append(FDFDict.translate_key('use-tree-timer'))
+    _aiida_blocked_keywords.append(FDFDict.translate_key('xml-write'))
+    _aiida_blocked_keywords.append(FDFDict.translate_key('dm-use-save-dm'))
+    _aiida_blocked_keywords.append(FDFDict.translate_key('geometry-must-converge'))
     _PSEUDO_SUBFOLDER = './'
     _OUTPUT_SUBFOLDER = './'
     _JSON_FILE = 'time.json'
@@ -169,19 +169,17 @@ class SiestaCalculation(CalcJob):
         input_params = FDFDict(parameters.get_dict())
 
         # Look for blocked keywords and add the proper values to the dictionary
-        for blocked_key in self._aiida_blocked_keywords:
-            canonical_blocked = FDFDict.translate_key(blocked_key)
-            for key in input_params:
-                if key == canonical_blocked:
-                    raise InputValidationError(
-                        "You cannot specify explicitly the '{}' flag in the "
-                        "input parameters".format(input_params.get_last_untranslated_key(key))
-                    )
-                if "pao" in key:
-                    raise InputValidationError(
-                        "You can not put PAO options in the parameters input port "
-                        "they belong to the basis input port "
-                    )
+        for key in input_params:
+            if "pao" in key:
+                raise InputValidationError(
+                    "You can not put PAO options in the parameters input port "
+                    "they belong to the basis input port "
+                )
+            if key in self._aiida_blocked_keywords:
+                raise InputValidationError(
+                    "You cannot specify explicitly the '{}' flag in the "
+                    "input parameters".format(input_params.get_last_untranslated_key(key))
+                )
 
         input_params.update({'system-name': self.inputs.metadata.options.prefix})
         input_params.update({'system-label': self.inputs.metadata.options.prefix})
@@ -286,13 +284,34 @@ class SiestaCalculation(CalcJob):
         #BandLinesScale =pi/a is not supported at the moment because currently
         #a=1 always. BandLinesScale ReciprocalLatticeVectors is always set
         if bandskpoints is not None:
+            #first we rise a warning about consequences when the cell is relaxed
+            var_cell_keys = [FDFDict.translate_key("md-variable-cell"), FDFDict.translate_key("md-constant-volume")]
+            var_cell_keys.append(FDFDict.translate_key("md-relax-cell-only"))
+            for key in input_params:
+                if key in var_cell_keys:
+                    logline = (
+                        "Requested calculation of bands after a relaxation with variable cell! " +
+                        "If the symmetry of the cell will change, the kpoints path for bands will be wrong. " +
+                        "It is suggested to use the `BandGapWorkChain` instead."
+                    )
+                    if isinstance(input_params[key], str):
+                        if FDFDict.translate_key(input_params[key]) in ["t", "true", "yes"]:
+                            self.logger.warning(logline)
+                            break
+                    else:
+                        if input_params[key] is True:
+                            self.logger.warning(logline)
+                            break
+            #the band line scale
             bandskpoints_card_list = ["BandLinesScale ReciprocalLatticeVectors\n"]
+            #set the BandPoints
             if bandskpoints.labels is None:
                 bandskpoints_card_list.append("%block BandPoints\n")
                 for kpo in bandskpoints.get_kpoints():
                     bandskpoints_card_list.append("{0:8.3f} {1:8.3f} {2:8.3f} \n".format(kpo[0], kpo[1], kpo[2]))
                 fbkpoints_card = "".join(bandskpoints_card_list)
                 fbkpoints_card += "%endblock BandPoints\n"
+            #set the BandLines
             else:
                 bandskpoints_card_list.append("%block BandLines\n")
                 savindx = []

--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -284,7 +284,16 @@ class SiestaCalculation(CalcJob):
         #BandLinesScale =pi/a is not supported at the moment because currently
         #a=1 always. BandLinesScale ReciprocalLatticeVectors is always set
         if bandskpoints is not None:
-            #first we rise a warning about consequences when the cell is relaxed
+            #first, we check that the user constracted the kpoints using the cell
+            #of the input structure, and not a random cell. This helps parsing
+            kpcell = bandskpoints.get_attribute("cell", None)
+            if kpcell:
+                if kpcell != structure.cell:
+                    raise ValueError(
+                        'The cell used for `bandskpoints` must be the same of the input structure.'
+                        'Alternatively do not set any cell to the bandskpoints.'
+                    )
+            #second we rise a warning about consequences when the cell is relaxed
             var_cell_keys = [FDFDict.translate_key("md-variable-cell"), FDFDict.translate_key("md-constant-volume")]
             var_cell_keys.append(FDFDict.translate_key("md-relax-cell-only"))
             for key in input_params:

--- a/aiida_siesta/docs/plugins/siesta.rst
+++ b/aiida_siesta/docs/plugins/siesta.rst
@@ -231,20 +231,18 @@ Some examples are referenced in the following list. They are located in the fold
 * **bandskpoints**, class :py:class:`KpointsData <aiida.orm.KpointsData>`, *Optional*
 
   Reciprocal space points for the calculation of bands.
-  This keyword is meant to facilitate the management of kpoints
-  exploiting the functionality
+  The **full list of kpoints must be passed** to ``bandskpoints``
+  and they must be in **units of the reciprocal lattice vectors**.
+  There is no obligation to set the cell in ``bandskpoints``, however this might be useful
+  in order to exploit the functionality
   of the class :py:class:`KpointsData <aiida.orm.KpointsData>`.
-  The full list of kpoints must be passed to the class
-  and they must be in units of the reciprocal lattice vectors.
-  Moreover the cell must be set in the :py:class:`KpointsData <aiida.orm.KpointsData>`
-  class.
-  
-  This can be achieved manually listing a set of kpoints::
-  
+  If set, the cell must be the same of the input **structure**.
+  Some examples on how to pass the kpoints are the following.
+
+  One can manually listing a set of isolated kpoints::
           from aiida.orm import KpointsData
           bandskpoints=KpointsData()
-          bandskpoints.set_cell(structure.cell, structure.pbc)
-          kpp = [(0.500,  0.250, 0.750), (0.500,  0.500, 0.500), (0., 0., 0.)]
+          kpp = [(0.1,  0.1, 0.1), (0.5,  0.5, 0.5), (0., 0., 0.)]
           bandskpoints.set_kpoints(kpp)
   In this case the Siesta input will use the "BandPoints" block.
   
@@ -263,14 +261,6 @@ Some examples are referenced in the following list. They are located in the fold
   In this case the block "BandLines" is set in the Siesta
   calculation.
 
-  .. note:: The ``get_explicit_kpoints_path`` make use of "SeeK-path".
-     Please cite the `HPKOT paper`_ if you use this tool. "SeeK-path"
-     is a external utility, not a requirement for aiida-core, therefore
-     it is not available by default. It can be easily installed using 
-     ``pip install seekpath``. "SeeK-path" allows to
-     determine canonical unit cells and k-point information in an easy
-     way. For more general information, refer to the `SeeK-path documentation`_.
-
   .. warning:: "SeeK-path"
      might modify the structure to follow particular conventions
      and the generated kpoints might only 
@@ -280,20 +270,37 @@ Some examples are referenced in the following list. They are located in the fold
      Siesta calculation::
           structure = kpresult['primitive_structure']
 
+  .. warning:: As we use the initial structure cell in order to obtain
+     the kpoints path, it is very risky to apply this method when also a relaxation
+     of the cell is performed!
+     The cell might relax in a different symmetry resulting in a wrong
+     path for the bands.
+     Consider to use the `BandGapWorkChain` if a relaxation is needed
+     before computing the bands.
+
+  .. note:: The ``get_explicit_kpoints_path`` make use of "SeeK-path".
+     Please cite the `HPKOT paper`_ if you use this tool. "SeeK-path"
+     is a external utility, not a requirement for aiida-core, therefore
+     it is not available by default. It can be easily installed using
+     ``pip install seekpath``. "SeeK-path" allows to
+     determine canonical unit cells and k-point information in an easy
+     way. For more general information, refer to the `SeeK-path documentation`_.
 
 
-  The final option (unrecommended) covers the situation
-  when one really needs to maintain a specific convention for the
-  structure or one needs to calculate the bands on a specific path
-  that is not a high-symmetry direction, the following (very involved)
-  option is available::
+  The final option covers the situation
+  when one needs to calculate the bands on a specific path
+  (and maybe needs to maintain a specific convention for the
+  structure). The full list of kpoints must be passed and, very
+  importantly, labels must be set for the high symmetry points!
+  This is essential for the correct set up of the "BandLines" in Siesta.
+  External tolls can be used to create equidistant points, whithin aiida
+  the following (very involved) option is available::
         from aiida.orm import KpointsData
         bandskpoints=KpointsData()
         from aiida.tools.data.array.kpoints.legacy import get_explicit_kpoints_path as legacy_path
         kpp = [('A',  (0.500,  0.250, 0.750), 'B', (0.500,  0.500, 0.500), 40),
         ('B', (0.500,  0.500, 0.500), 'C', (0., 0., 0.), 40)]
         tmp=legacy_path(kpp)
-        bandskpoints.set_cell(structure.cell, structure.pbc)
         bandskpoints.set_kpoints(tmp[3])
         bandskpoints.labels=tmp[4]
   The legacy ``get_explicit_kpoints_path`` shares only the name with the function in
@@ -303,8 +310,8 @@ Some examples are referenced in the following list. They are located in the fold
 
   .. warning:: The implementation relies on the correct description of
      the labels in the class :py:class:`KpointsData <aiida.orm.KpointsData>`.
-     Refrain from the use of ``bandskpoints.labels`` in any other
-     situation apart from the one described above. An incorrect use of the labels
+     Refrain from improper use of ``bandskpoints.labels`` and follow the 
+     the instructions described above. An incorrect use of the labels
      might result in an incorrect parsing of the bands.
 
   If the keyword node **bandskpoints** is not present, no band structure is computed.

--- a/aiida_siesta/docs/workflows/bandgap.rst
+++ b/aiida_siesta/docs/workflows/bandgap.rst
@@ -5,13 +5,9 @@ Description
 -----------
 
 The **BandgapWorkChain** is an extension of the **SietaBaseWorkChain** 
-that introduces a simple post-process with the scope to return the metallic or
+that introduces some logic to automatically obtain the bands and
+applyes a simple post-process with the scope to return the metallic or
 insulating nature of the material and, possibly, the band gap.
-The purpose of this WorkChain is mostly educational, showing how easy is
-to introduce pre-processes or post-processes in the WorkChain logic.
-The class **BandgapWorkChain** is, in fact, a subclass of the **SietaBaseWorkChain**
-that just overrides few methods and introduces the
-additional output **band_gap_info**.
 
 To calculate the gap, this workchain makes use of a tool distributed in aiida-core,
 the method ``find_bandgap`` hosted in ``aiida.orm.nodes.data.array.bands``.
@@ -33,8 +29,21 @@ All the **SiestaBaseWorkChain** inputs are as well inputs of the **BangapWorkCha
 therefore the system and DFT specifications (structure, parameters, etc.) are
 inputted in the WorkChain using the same syntax explained in the **SiestaBaseWorkChain**
 :ref:`documentation <siesta-base-wc-inputs>`.
-The only difference is that the **bandskpoints** are now a mandatory input and the WorkChain
-will rise an error if they are not present.
+There is however the addition of an importan feature. If **bandskpoints** are not set
+in inputs, the **BandgapWorkChain** will anyway calculate the bands following these rules:
+
+* If a single-point calculation is requested, the kpoints path for bands is set automatically using seekpath.
+Please note that this choice might change the structure, as explained here.
+
+* If a relaxation was asked, first a siesta calculation without bands is performed to take
+care of the relaxation, then a separate single-point calculation is set up and the bands are
+calculated for a symmetry path in k-space decided by seekpath using the output structure of the relaxation.
+This overcomes the problem of the compatibility between bands and variable-cell relaxations.
+In fact, the final cell obtained from a relaxation, can not be known in advance, and to set
+the kpoint path without knowing the cell is generally a poor choice.
+Again note that seekpath might change the structure, in this second case, only the structure
+of the final single-point calculation will be changed. The changed structure is returned as
+**output_structure** port of the workchain.
 
 Outputs
 -------

--- a/aiida_siesta/docs/workflows/bandgap.rst
+++ b/aiida_siesta/docs/workflows/bandgap.rst
@@ -36,18 +36,18 @@ There is however the addition of an importan feature. If **bandskpoints** are no
 in inputs, the **BandgapWorkChain** will anyway calculate the bands following these rules:
 
 * If a single-point calculation is requested, the kpoints path for bands is set automatically using SeeK-path.
-Please note that this choice might change the structure, as explained in the 
-`SeeK-path`_ documentation.
+  Please note that this choice might change the structure, as explained in the 
+  `SeeK-path`_ documentation.
 
 * If a relaxation was asked, first a siesta calculation without bands is performed to take
-care of the relaxation, then a separate single-point calculation is set up and the bands are
-calculated for a symmetry path in k-space decided by SeeK-path using the output structure of the relaxation.
-This overcomes the problem of the compatibility between bands and variable-cell relaxations.
-In fact, the final cell obtained from a relaxation, can not be known in advance, and to set
-the kpoint path without knowing the cell is generally a poor choice.
-Again note that SeeK-path might change the structure. In this second case, only the structure
-of the final single-point calculation will be changed. The changed structure is returned as
-**output_structure** port of the workchain.
+  care of the relaxation, then a separate single-point calculation is set up and the bands are
+  calculated for a symmetry path in k-space decided by SeeK-path using the output structure of the relaxation.
+  This overcomes the problem of the compatibility between bands and variable-cell relaxations.
+  In fact, the final cell obtained from a relaxation, can not be known in advance, and to set
+  the kpoint path without knowing the cell is generally a poor choice.
+  Again note that SeeK-path might change the structure. In this second case, only the structure
+  of the final single-point calculation will be changed. The changed structure is returned as
+  **output_structure** port of the workchain.
 
 If the **bandskpoints** is set by the user in inputs, no action is
 taken and the behaviour follow what explained for the **SiestaBaseWorkChain**

--- a/aiida_siesta/docs/workflows/bandgap.rst
+++ b/aiida_siesta/docs/workflows/bandgap.rst
@@ -12,6 +12,9 @@ insulating nature of the material and, possibly, the band gap.
 To calculate the gap, this workchain makes use of a tool distributed in aiida-core,
 the method ``find_bandgap`` hosted in ``aiida.orm.nodes.data.array.bands``.
 
+The optional automatic generation of the kpoints path for the bands
+is done using `SeeK-path`_.
+
 Supported Siesta versions
 -------------------------
 
@@ -32,18 +35,35 @@ inputted in the WorkChain using the same syntax explained in the **SiestaBaseWor
 There is however the addition of an importan feature. If **bandskpoints** are not set
 in inputs, the **BandgapWorkChain** will anyway calculate the bands following these rules:
 
-* If a single-point calculation is requested, the kpoints path for bands is set automatically using seekpath.
-Please note that this choice might change the structure, as explained here.
+* If a single-point calculation is requested, the kpoints path for bands is set automatically using SeeK-path.
+Please note that this choice might change the structure, as explained in the 
+`SeeK-path`_ documentation.
 
 * If a relaxation was asked, first a siesta calculation without bands is performed to take
 care of the relaxation, then a separate single-point calculation is set up and the bands are
-calculated for a symmetry path in k-space decided by seekpath using the output structure of the relaxation.
+calculated for a symmetry path in k-space decided by SeeK-path using the output structure of the relaxation.
 This overcomes the problem of the compatibility between bands and variable-cell relaxations.
 In fact, the final cell obtained from a relaxation, can not be known in advance, and to set
 the kpoint path without knowing the cell is generally a poor choice.
-Again note that seekpath might change the structure, in this second case, only the structure
+Again note that SeeK-path might change the structure. In this second case, only the structure
 of the final single-point calculation will be changed. The changed structure is returned as
 **output_structure** port of the workchain.
+
+If the **bandskpoints** is set by the user in inputs, no action is
+taken and the behaviour follow what explained for the **SiestaBaseWorkChain**
+:ref:`documentation <siesta-base-wc-inputs>`.
+
+An additional input is present:
+
+* **seekpath_dict** class :py:class:`Dict <aiida.orm.Dict>`, *Optional*
+ 
+  Dictionary hosting the parametrs to pass to the ``get_explicit_kpoints_path``
+  method of SeeK-path.
+  The default sets ``{'reference_distance': 0.02, 'symprec': 0.0001}``,
+  meaning target distance between neighboring k-points of 
+  0.02 1/ang and symmetry precision parameter of 0.0001.
+  Full list of the possible options and their explanation
+  can be found `here`_.
 
 Outputs
 -------
@@ -65,6 +85,9 @@ Protocol system
 ---------------
 
 The protocol system is available for this WorkChain. The ``BandgapWorkChain.inputs_generator()``
-makes available all the methods explained in the :ref:`protocols documentation <how-to>`, the
-only difference is that here is mandatory to pass ``bands_path_generator`` to ``get_filled_builder`` and
-not optional like for the **SietaBaseWorkChain** inputs generator.
+makes available all the methods explained in the :ref:`protocols documentation <how-to>`. The bands
+options are still valid and they will set a `bandskpoints` input to the workchain. To avail of
+the automatic generation of bands path, do not pass any ``bands_path_generator`` to ``get_filled_builder``.
+
+.. _SeeK-path: https://seekpath.readthedocs.io/en/latest/
+.. _here: https://seekpath.readthedocs.io/en/latest/module_guide/index.html#seekpath.getpaths.get_explicit_k_path

--- a/aiida_siesta/examples/plugins/siesta/example_bands.py
+++ b/aiida_siesta/examples/plugins/siesta/example_bands.py
@@ -118,7 +118,6 @@ bandskpoints = result['explicit_kpoints']
 ##Mandatory to set cell and pbc. Do not set labels!
 ##This calls BandsPoint
 #kpp = [(0.500,  0.250, 0.750), (0.500,  0.500, 0.500), (0., 0., 0.)]
-#bandskpoints.set_cell(structure.cell, structure.pbc)
 #bandskpoints.set_kpoints(kpp)
 ##3)
 ##...The option to define a path touching specific kpoints...
@@ -127,7 +126,6 @@ bandskpoints = result['explicit_kpoints']
 #kpp = [('W',  (0.500,  0.250, 0.750), 'L', (0.500,  0.500, 0.500), 40),
 #        ('L', (0.500,  0.500, 0.500), 'G', (0., 0., 0.), 40)]
 #tmp=legacy_path(kpp)
-#bandskpoints.set_cell(structure.cell, structure.pbc)
 #bandskpoints.set_kpoints(tmp[3])
 #bandskpoints.labels=tmp[4]
 

--- a/aiida_siesta/examples/plugins/siesta/example_bands.py
+++ b/aiida_siesta/examples/plugins/siesta/example_bands.py
@@ -115,13 +115,12 @@ bandskpoints = KpointsData()
 bandskpoints = result['explicit_kpoints']
 ##2)
 ##.................Only discrete points.............
-##Mandatory to set cell and pbc. Do not set labels!
 ##This calls BandsPoint
 #kpp = [(0.500,  0.250, 0.750), (0.500,  0.500, 0.500), (0., 0., 0.)]
 #bandskpoints.set_kpoints(kpp)
 ##3)
 ##...The option to define a path touching specific kpoints...
-##It make use of a legacy function. Mandatory to set cell and pbc
+##It make use of a legacy function.
 #from aiida.tools.data.array.kpoints.legacy import get_explicit_kpoints_path as legacy_path
 #kpp = [('W',  (0.500,  0.250, 0.750), 'L', (0.500,  0.500, 0.500), 40),
 #        ('L', (0.500,  0.500, 0.500), 'G', (0., 0., 0.), 40)]

--- a/aiida_siesta/examples/workflows/example_bandgap.py
+++ b/aiida_siesta/examples/workflows/example_bandgap.py
@@ -125,6 +125,7 @@ inputs = {
     'kpoints': kpoints,
     'pseudos': pseudos_dict,
     'options': options,
+    #'seekpath_dict': Dict(dict={'symprec': 0.00000001, 'reference_distance': 0.2})
     #'bandskpoints': bandskpoints
 }
 

--- a/aiida_siesta/examples/workflows/example_bandgap.py
+++ b/aiida_siesta/examples/workflows/example_bandgap.py
@@ -67,7 +67,7 @@ parameters = Dict(
         'Solution-method': 'diagon',
         'electronic-temperature': '25 meV',
         'write-forces': True,
-        'md-steps' : 0,
+        'md-steps' : 10,
     })
 
 #The basis set

--- a/aiida_siesta/examples/workflows/example_bandgap.py
+++ b/aiida_siesta/examples/workflows/example_bandgap.py
@@ -60,13 +60,14 @@ parameters = Dict(
     dict={
         'xc-functional': 'LDA',
         'xc-authors': 'CA',
-        'max-scfiterations': 4,
+        'max-scfiterations': 40,
         'dm-numberpulay': 4,
         'dm-mixingweight': 0.3,
         'dm-tolerance': 1.e-5,
         'Solution-method': 'diagon',
         'electronic-temperature': '25 meV',
         'write-forces': True,
+        'md-steps' : 0,
     })
 
 #The basis set
@@ -124,7 +125,7 @@ inputs = {
     'kpoints': kpoints,
     'pseudos': pseudos_dict,
     'options': options,
-    'bandskpoints': bandskpoints
+    #'bandskpoints': bandskpoints
 }
 
 process = submit(BandgapWorkChain, **inputs)

--- a/aiida_siesta/utils/inputs_generators.py
+++ b/aiida_siesta/utils/inputs_generators.py
@@ -205,26 +205,26 @@ class BaseWorkChainInputsGenerator(SiestaCalculationInputsGenerator):
         return inps
 
 
-class BandgapWorkChainInputsGenerator(BaseWorkChainInputsGenerator):
-    """
-    Inputs generator for the BandgapWorkChain, makes use of the methods
-    of the BaseWorkChainInputsGenerator, only the __init__ requires the correct
-    workchain class in input and the `get_inputs_dict` implements a check for the
-    presence of `bands_path_generator`. In fact the band calculation is required.
-    """
-
-    def get_inputs_dict(
-        self, structure, calc_engines, protocol, bands_path_generator=None, relaxation_type=None, spin=None
-    ):
-
-        if not bands_path_generator:
-            raise RuntimeError(
-                'Method `get_inputs_dict` of class `{0}` requires `bands_path_generator`'.format(
-                    self.__class__.__name__
-                )
-            )
-
-        return super().get_inputs_dict(structure, calc_engines, protocol, bands_path_generator, relaxation_type, spin)
+#class BandgapWorkChainInputsGenerator(BaseWorkChainInputsGenerator):
+#    """
+#    Inputs generator for the BandgapWorkChain, makes use of the methods
+#    of the BaseWorkChainInputsGenerator, only the __init__ requires the correct
+#    workchain class in input and the `get_inputs_dict` implements a check for the
+#    presence of `bands_path_generator`. In fact the band calculation is required.
+#    """
+#
+#    def get_inputs_dict(
+#        self, structure, calc_engines, protocol, bands_path_generator=None, relaxation_type=None, spin=None
+#    ):
+#
+#        if not bands_path_generator:
+#            raise RuntimeError(
+#                'Method `get_inputs_dict` of class `{0}` requires `bands_path_generator`'.format(
+#                    self.__class__.__name__
+#                )
+#            )
+#
+#        return super().get_inputs_dict(structure, calc_engines, protocol, bands_path_generator, relaxation_type, spin)
 
 
 class EosWorkChainInputsGenerator(BaseWorkChainInputsGenerator):

--- a/aiida_siesta/workflows/bandgap.py
+++ b/aiida_siesta/workflows/bandgap.py
@@ -135,7 +135,7 @@ class BandgapWorkChain(WorkChain):
             if not self.ctx.final_run.is_finished_ok:
                 return self.exit_codes.ERROR_FINAL_WC
             outps = self.ctx.final_run.outputs
-            self.out('output_structure', self.ctx.workchain_base.outputs.output_structure)
+            self.out('output_structure', self.ctx.final_run.inputs.structure)
         else:
             outps = self.ctx.workchain_base.outputs
 

--- a/tests/calculations/test_siesta.py
+++ b/tests/calculations/test_siesta.py
@@ -122,7 +122,7 @@ def test_blocked_keyword(aiida_profile, fixture_sandbox, generate_calc_job,
     psml = generate_psml_data('Si')
 
     parameters = generate_param()
-    #parameters.set_attribute('system-name',"whatever")
+    parameters.set_attribute('system-name',"whatever")
     parameters.set_attribute('pao-sp',"whatever")
 
     inputs = {

--- a/tests/parsers/test_siesta/test_siesta_bandspoints.yml
+++ b/tests/parsers/test_siesta/test_siesta_bandspoints.yml
@@ -5,8 +5,21 @@ bands:
   array|kpoints:
   - 3
   - 3
+  cell:
+  - - 2.715
+    - 2.715
+    - 0.0
+  - - 2.715
+    - 0.0
+    - 2.715
+  - - 0.0
+    - 2.715
+    - 2.715
   label_numbers: []
   labels: []
+  pbc1: true
+  pbc2: true
+  pbc3: true
   units: eV
 forces_and_stress:
   array|forces:

--- a/tests/utils/test_inputs_generators.py
+++ b/tests/utils/test_inputs_generators.py
@@ -39,21 +39,21 @@ def test_baseworkchain_inpgen(aiida_profile, fixture_code, generate_structure):
 
     assert "parameters" in build
 
-def test_bandgapworkchain_inpgen(aiida_profile, fixture_code, generate_structure):
-    """Test the validation of subclasses of `InputsGenerator`."""
+#def test_bandgapworkchain_inpgen(aiida_profile, fixture_code, generate_structure):
+#    """Test the validation of subclasses of `InputsGenerator`."""
 
-    from aiida_siesta.utils.inputs_generators import BandgapWorkChainInputsGenerator
+#    from aiida_siesta.utils.inputs_generators import BandgapWorkChainInputsGenerator
 
-    inp_gen = BandgapWorkChainInputsGenerator(WorkflowFactory("siesta.bandgap"))
-    structure = generate_structure()
-    protocol = inp_gen.get_default_protocol_name()
-    code = fixture_code("siesta.siesta")
-    code.store()
-    calc_engines = {"siesta": {'code': code.uuid, 'options': {"resources": {"num_mpiprocs_per_machine": 1}, "max_wallclock_seconds": 360}}}
+#    inp_gen = BandgapWorkChainInputsGenerator(WorkflowFactory("siesta.bandgap"))
+#    structure = generate_structure()
+#    protocol = inp_gen.get_default_protocol_name()
+#    code = fixture_code("siesta.siesta")
+#    code.store()
+#    calc_engines = {"siesta": {'code': code.uuid, 'options': {"resources": {"num_mpiprocs_per_machine": 1}, "max_wallclock_seconds": 360}}}
 
-    build = inp_gen.get_filled_builder(structure, calc_engines, protocol, bands_path_generator="seekpath")
+#    build = inp_gen.get_filled_builder(structure, calc_engines, protocol, bands_path_generator="seekpath")
 
-    assert "parameters" in build
+#    assert "parameters" in build
 
 def test_eosworkchain_inpgen(aiida_profile, fixture_code, generate_structure):
     """Test the validation of subclasses of `InputsGenerator`."""

--- a/tests/workflows/test_bandgap.py
+++ b/tests/workflows/test_bandgap.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env runaiida
 import pytest
+from plumpy import ProcessState
 from aiida import orm
-
+from aiida.common import (LinkType, AttributeDict)
+from aiida.engine import ExitCode
 
 @pytest.fixture
 def generate_workchain_bandgap(generate_psml_data, fixture_code, fixture_localhost, generate_workchain, 
@@ -9,20 +11,17 @@ def generate_workchain_bandgap(generate_psml_data, fixture_code, fixture_localho
         generate_calc_job_node, generate_parser):
     """Generate an instance of a `BandgapWorkChain`."""
 
-    def _generate_workchain_bandgap(bands=False):
+    def _generate_workchain_bandgap(bands=False,relax=False):
 
         entry_point_wc = 'siesta.bandgap'
         entry_point_code = 'siesta.siesta'
 
         psml = generate_psml_data('Si')
 
-        structure = generate_structure()
-
         inputs = {
             'code': fixture_code(entry_point_code),
-            'structure': structure,
+            'structure': generate_structure(),
             'kpoints': generate_kpoints_mesh(2),
-            'parameters': generate_param(),
             'basis': generate_basis(),
             'pseudos': {
                 'Si': psml,
@@ -35,10 +34,18 @@ def generate_workchain_bandgap(generate_psml_data, fixture_code, fixture_localho
                })
         }
 
+        if relax:
+            inputs["parameters"] = generate_param()
+        else:
+            param = generate_param().get_dict()
+            for item in param.copy():
+                if item.startswith("md"):
+                    param.pop(item)
+            inputs["parameters"] = orm.Dict(dict=param)
+
         if bands:
             bandskpoints = orm.KpointsData()
             kpp = [(0.500,  0.250, 0.750), (0.500,  0.500, 0.500), (0., 0., 0.)]
-            bandskpoints.set_cell(structure.cell, structure.pbc)
             bandskpoints.set_kpoints(kpp)
             inputs["bandskpoints"] = bandskpoints
 
@@ -49,42 +56,97 @@ def generate_workchain_bandgap(generate_psml_data, fixture_code, fixture_localho
 
     return _generate_workchain_bandgap
 
-def test_setup_fail(aiida_profile, generate_workchain_bandgap):
-    """Test `BangapWorkChain.setup`."""
-    with pytest.raises(ValueError):
-        process = generate_workchain_bandgap()
-        process.preprocess()
-        process.setup()
-        process.prepare_inputs()
+def test_preproc_and_add_kpb(aiida_profile, generate_workchain_bandgap):
+    """Test `BangapWorkChain.preprocess`."""
 
-def test_setup(aiida_profile, generate_workchain_bandgap):
-    """Test `BangapWorkChain.setup`."""
-    
     process = generate_workchain_bandgap(bands=True)
     process.preprocess()
-    process.setup()
-    process.prepare_inputs()
+    assert not process.ctx.need_to_generate_bandskp
+    assert not process.ctx.need_fin_step
 
-    assert isinstance(process.ctx.inputs, dict)
+    process = generate_workchain_bandgap(bands=False,relax=False)
+    process.preprocess()
+    assert process.ctx.need_to_generate_bandskp
+    assert not process.ctx.need_fin_step 
 
-def test_postprocess(aiida_profile, generate_workchain_bandgap):
-#    """Test `BangapWorkChain.setup`."""
-#
+    res = process.run_siesta_wc()
+
+    assert "bandskpoints" in res['workchain_base'].inputs
+
+
+def test_preproc_and_relax(aiida_profile, fixture_localhost, fixture_code, generate_psml_data,
+        generate_structure, generate_wc_job_node, generate_workchain_bandgap):
+    """Test `BangapWorkChain.setup`."""
+
+    process = generate_workchain_bandgap(bands=False,relax=True)
+    process.preprocess()
+    assert not process.ctx.need_to_generate_bandskp
+    assert process.ctx.need_fin_step
+
+    res = process.run_siesta_wc()
+
+    assert not "bandskpoints" in res['workchain_base'].inputs
+
+    psml = generate_psml_data("Si")
+
+    inputs = AttributeDict({
+        'structure': generate_structure(),
+        'code': fixture_code("siesta.siesta"),
+        'parameters': orm.Dict(dict={"md": 3, "ee":4}),
+        'options': orm.Dict(dict={'resources': {'num_machines': 1  },'max_wallclock_seconds': 1800,'withmpi': False}),
+        'pseudos': {'Si': psml,'SiDiff': psml},
+    })
+    fin_basewc = generate_wc_job_node("siesta.base", fixture_localhost, inputs)
+    fin_basewc.set_process_state(ProcessState.FINISHED)
+    fin_basewc.set_exit_status(ExitCode(0).status)
+    out_struct = generate_structure()
+    out_struct.store()
+    out_struct.add_incoming(fin_basewc, link_type=LinkType.RETURN, link_label='output_structure')
+
+    process.ctx.workchain_base = fin_basewc
+
+    finwc = process.run_last()
+
+    assert "bandskpoints" in finwc['final_run'].inputs
+    assert finwc['final_run'].inputs.parameters.get_dict() == {"ee":4}
+
+
+def test_final_run(aiida_profile, fixture_localhost, generate_workchain_bandgap, generate_wc_job_node):
+    """Test `BangapWorkChain.setup`."""
+
     process = generate_workchain_bandgap(bands=True)
-    process.out('output_parameters', orm.Dict(dict={'E_Fermi' : -1}))
+
+    process.ctx.need_fin_step = False
+
+    fin_basewc = generate_wc_job_node("siesta.base", fixture_localhost)
+    fin_basewc.set_process_state(ProcessState.FINISHED)
+    fin_basewc.set_exit_status(ExitCode(0).status)
+    
+    out_par = orm.Dict(dict={'E_Fermi' : -1})
+    out_par.store()
+    out_par.add_incoming(fin_basewc, link_type=LinkType.RETURN, link_label='output_parameters')
+    
+    out_force_stress = orm.ArrayData()
+    out_force_stress.store()
+    out_force_stress.add_incoming(fin_basewc, link_type=LinkType.RETURN, link_label='forces_and_stress')
+    
+    remote_folder = orm.RemoteData(computer=fixture_localhost, remote_path='/tmp')
+    remote_folder.store()
+    remote_folder.add_incoming(fin_basewc, link_type=LinkType.RETURN, link_label='remote_folder')
+
     bands = orm.BandsData()
     bkp = process.inputs.bandskpoints
-    bands.set_kpoints(bkp.get_kpoints(cartesian=True))
-    #bands.labels = bkp.labels
+    bands.set_kpointsdata(bkp)
     import numpy as np
     bands.set_bands(np.array([[-2,1,3],[-2,1,3],[-2,1,3]]), units="eV")
-    process.out('bands', bands)
-    process.postprocess()
+    out_bands = bands
+    out_bands.store()
+    out_bands.add_incoming(fin_basewc, link_type=LinkType.RETURN, link_label='bands')
+   
+    process.ctx.workchain_base = fin_basewc
+    process.run_results()
 
     res = process.outputs["band_gap_info"]
     assert isinstance(res,orm.Dict)
     assert res['is_insulator']
     assert res['band_gap'] == 3.0
-
-    #assert isinstance(process.ctx.inputs, dict)
-


### PR DESCRIPTION
This PR introduces various changes:
1) Fixes #79, in the sense that the parser now will use the final structure to set the distance between kpoints (for plotting purposes) if a relaxation has been performed. Kpoints are in fact always passed in reciprocal axis units.
2) Fixes #79, in the sense that we now allow to pass to `banskpoints` a set of kpoints in reciprocal space without the need of specifying a cell.
3) Imposes that, if a cell is set in `bandskpoints`, it must be the same one of the input `structure`.
4) Introduces a warning if a relaxation with variable cell is requested together with bands.
5) Tries to make the `BangGapWorkChain` smarter introducing a new feature: if no `bandskpoints` is specified in input, the workchain sets the calculation of bands automatically. If single-point calculation, the bands are set using seekpath since the beginning. If a relaxation was requested, the relaxation is performed and the bands are calculated on an extra final step, where seekpath sets the kpoints path for bands using the final structure. Please remember that seekpath might change the structure to follow conventions. Also note that the choice is fully back compatible. If a users specify `bandskpoints` in input, the same behavior of before is set, including the limitation that the kpoints are set in the beginning and might result to be insignificant if the cell changes. However this is also possible in Siesta itself.

@pfebrer96's review is requested to check if the implementation fits his needs and it is correct (if would be appreciate a comparison between bands parsed here and maybe sisl.
@albgar's review would be appreciated for point 5). 