### PR TITLE
Fixed bugs of `SequentialConverger`.

### DIFF
--- a/aiida_siesta/docs/workflows/seq_converger.rst
+++ b/aiida_siesta/docs/workflows/seq_converger.rst
@@ -72,6 +72,15 @@ Two are the required inputs:
   Note that one can converge the same parameters again if wanted,
   for instance set up different rounds for kpoints convergence.
 
+.. warning:: If one of the parameters does not converge, no action is taken and
+   the following convergence step is performed using the inputs specified in **converger_inputs**,
+   not using the last attempted value in the previous convergence.
+   For instance, in the example above, if the ``meshcutoff`` does not converged at ``900 Ry``,
+   the ``pao-energyshift`` convergence will be done using the inputs parameters
+   specified in the ``parameters`` of ``converger_inputs``, not including
+   ``meshcutoff = "900 Ry"``.
+
+
 
 Outputs
 -------
@@ -82,7 +91,7 @@ The following outputs are returned:
 * **converged_target_value** :py:class:`Dict <aiida.orm.Dict>`
 
   The value of the target when the convergence has been reached. Returned only if
-  the convergence is succesfull.
+  at least one of the sequential convergences has been completed succesfull.
 
 .. |br| raw:: html
 
@@ -91,7 +100,7 @@ The following outputs are returned:
 * **converged_parameters** :py:class:`Dict <aiida.orm.Dict>`
 
   The values for the parameters that was enough to achieve convergence.
-  If converged is not achieved, it won't be returned.
+  If converged is not achieved, it will be an empty dictionary.
 
 
 Protocol system

--- a/aiida_siesta/docs/workflows/seq_converger.rst
+++ b/aiida_siesta/docs/workflows/seq_converger.rst
@@ -102,6 +102,15 @@ The following outputs are returned:
   The values for the parameters that was enough to achieve convergence.
   If converged is not achieved, it will be an empty dictionary.
 
+.. |br| raw:: html
+
+    <br />
+
+* **unconverged_parameters** :py:class:`List <aiida.orm.List>`
+
+  If one or more parameters fail to converge, we list them
+  in this output.
+
 
 Protocol system
 ---------------

--- a/aiida_siesta/utils/converge_absclass.py
+++ b/aiida_siesta/utils/converge_absclass.py
@@ -217,7 +217,7 @@ class SequentialConverger(BaseIterator):
             help="The values for the parameters that was enough to achieve convergence. "
             "If converged is not achieved, it won't be returned",
         )
-        spec.output('converged_target_value', help="The value of the target with convergence reached.")
+        spec.output('converged_target_value', required=False, help="The value of the target with convergence reached.")
 
     @classmethod
     def _iterate_input_serializer(cls, iterate_over):
@@ -297,9 +297,10 @@ class SequentialConverger(BaseIterator):
 
             self.ctx._iteration_parsing = {"iterate_over": {}}
 
-        self.ctx.last_target_value = process_node.outputs.converged_target_value
+            self.ctx.last_target_value = process_node.outputs.converged_target_value
 
     def return_results(self):
 
         self.out('converged_parameters', DataFactory('dict')(dict=self.ctx.already_converged).store())
-        self.out('converged_target_value', self.ctx.last_target_value)
+        if "last_target_value" in self.ctx:
+            self.out('converged_target_value', self.ctx.last_target_value)

--- a/aiida_siesta/utils/iterate_absclass.py
+++ b/aiida_siesta/utils/iterate_absclass.py
@@ -5,9 +5,8 @@ import numpy as np
 
 from aiida.plugins import DataFactory
 from aiida.engine import WorkChain, while_, ToContext
-from aiida.orm import Str, List, Int, Node
+from aiida.orm import Str, List, Int, Node, load_node
 from aiida.orm.nodes.data.base import to_aiida_type
-from aiida.orm.utils import load_node
 from aiida.common import AttributeDict
 
 

--- a/tests/workflows/test_converge.py
+++ b/tests/workflows/test_converge.py
@@ -163,7 +163,8 @@ def test_sequential_not_conv(aiida_profile, generate_workchain_seq_converger, ge
 
     assert process.ctx.iteration_keys == ('iterate_over',)
 
-    convergerwc = generate_wc_job_node("siesta.converger", fixture_localhost)
+    inputs = {"iterate_over": orm.Dict(dict={"s":[2,2]})}
+    convergerwc = generate_wc_job_node("siesta.converger", fixture_localhost, inputs)
     convergerwc.set_process_state(ProcessState.FINISHED)
     convergerwc.set_exit_status(ExitCode(0).status)
     out_conv = orm.Bool(False)


### PR DESCRIPTION
Fixes #82.
The parsing of `converged_target_value` output of a convergence workchain is now
done only when the convergence has been successful.
The output `converged_target_value` is returned only if the attribute
`last_target_value` is present in `self.ctx`. It might not be present
if all the convergence workchains fail.