### PR TITLE
Flag to control MD.TypeOfRun when using LUA

### DIFF
--- a/aiida_siesta/calculations/siesta.py
+++ b/aiida_siesta/calculations/siesta.py
@@ -312,6 +312,7 @@ class SiestaCalculation(CalcJob):
         spec.input('lua.parameters', valid_type=orm.Dict, required=False)
         spec.input('lua.input_files', valid_type=orm.FolderData, required=False)
         spec.input('lua.retrieve_list', valid_type=orm.List, required=False)
+        spec.input('lua.md_run', valid_type=orm.Bool, default=lambda: orm.Bool(True), required=False)
 
         # Metadada.options host the inputs that are not stored as a separate node, but attached to `CalcJobNode`
         # as attributes. They are optional, since a default is specified, but they might be changed by the user.
@@ -446,6 +447,8 @@ class SiestaCalculation(CalcJob):
         else:
             lua_retrieve_list = None
 
+        lua_md_run = lua_inputs.md_run
+
         # List of files to copy in the folder where the calculation runs, e.g. pseudo files
         local_copy_list = []
 
@@ -465,7 +468,8 @@ class SiestaCalculation(CalcJob):
         input_params.update({'lattice-constant': '1.0 Ang'})
         input_params.update({'atomic-coordinates-format': 'Ang'})
         if lua_script is not None:
-            input_params.update({'md-type-of-run': 'Lua'})
+            if lua_md_run.value:
+                input_params.update({'md-type-of-run': 'Lua'})
             input_params.update({'lua-script': lua_script.filename})
             local_copy_list.append((lua_script.uuid, lua_script.filename, lua_script.filename))
         if lua_input_files is not None:

--- a/aiida_siesta/docs/plugins/siesta.rst
+++ b/aiida_siesta/docs/plugins/siesta.rst
@@ -434,6 +434,7 @@ Some examples are referenced in the following list. They are located in the fold
         spec.input('lua.parameters', valid_type=orm.Dict, required=False)
         spec.input('lua.input_files', valid_type=orm.FolderData, required=False)
         spec.input('lua.retrieve_list', valid_type=orm.List, required=False)
+	spec.input('lua.md_run', valid_type=orm.Bool, default=lambda: orm.Bool(True), required=False)
 
 * **lua.script** is a Lua script implementing a specific
   functionality, and possibly being able to set its own
@@ -454,6 +455,9 @@ Some examples are referenced in the following list. They are located in the fold
   produced by the operation of the Lua script that need to be
   retrieved. They should be parsed by functionality-specific
   modules in client workchains.
+
+* **lua.md_run** is a flag which controls whether we should set
+  ``MD.TypeOfRun`` to ``Lua``.
 
 .. |br| raw:: html
 

--- a/tests/calculations/test_siesta/test_lua_md_run.fdf
+++ b/tests/calculations/test_siesta/test_lua_md_run.fdf
@@ -1,0 +1,50 @@
+atomiccoordinatesformat Ang
+dmmixingweight 0.3
+dmnumberpulay 4
+dmtolerance 0.001
+electronictemperature 25 meV
+geometrymustconverge T
+latticeconstant 1.0 Ang
+luascript relax_geometry_lbfgs.lua
+maxscfiterations 50
+mdmaxcgdispl 0.1 Ang
+mdmaxforcetol 0.04 eV/Ang
+mdnumcgsteps 3
+mdtypeofrun cg
+numberofatoms 2
+numberofspecies 2
+solutionmethod diagon
+systemlabel aiida
+systemname aiida
+usetreetimer T
+xcauthors CA
+xcfunctional LDA
+xmlwrite T
+#
+# -- Structural Info follows
+#
+%block chemicalspecieslabel
+    1    14     Si
+    2    14 SiDiff
+%endblock chemicalspecieslabel
+%block lattice-vectors
+      2.7150000000       2.7150000000       0.0000000000
+      2.7150000000       0.0000000000       2.7150000000
+      0.0000000000       2.7150000000       2.7150000000
+%endblock lattice-vectors
+%block atomiccoordinatesandatomicspecies
+      0.0000000000       0.0000000000       0.0000000000    1     Si      1
+      1.3575000000       1.3575000000       1.3575000000    2 SiDiff      2
+%endblock atomiccoordinatesandatomicspecies
+#
+# -- K-points Info follows
+#
+%block kgrid_monkhorst_pack
+     2      0      0       0.0000000000
+     0      2      0       0.0000000000
+     0      0      2       0.0000000000
+%endblock kgrid_monkhorst_pack
+#
+# -- Max wall-clock time block
+#
+maxwalltime 1800


### PR DESCRIPTION
In my calculations I often use Lua scripts to do some constrained structural relaxations, where I still use the internal siesta relaxations algorithms (by setting `MD.TypeOfRun` to something other than `Lua`) and I use the Lua script to update certain internal siesta variables between relaxation steps. This was not possible with the current version of the AiiDA plugin because if you include a lua script it will always override `MD.TypeOfRun` and set it to `Lua`. Therefore, I added to flag to allow a user to change this behaviour. Maybe you could consider merging this into the plugin?